### PR TITLE
Feat: implement round_series_to_precision() method and tests for it

### DIFF
--- a/pyledger/ledger_engine.py
+++ b/pyledger/ledger_engine.py
@@ -944,6 +944,26 @@ class LedgerEngine(ABC):
         result = round(amount / precision, 0) * precision
         return round(result, -1 * math.floor(math.log10(precision)))
 
+    def round_series_to_precision(
+        self,
+        amount: pd.Series,
+        currency: pd.Series,
+    ) -> pd.Series:
+        """Round the amounts in the series to the specified precision based on the currency.
+
+        Args:
+            amount (pd.Series): Series of amounts to round.
+            currency (pd.Series): Series of currency codes corresponding to each amount.
+
+        Returns:
+            pd.Series: Series with amounts rounded to the specified precision.
+        """
+        rounded_values = [
+            pd.NA if pd.isna(amt) else self.round_to_precision(amt, curr)
+            for amt, curr in zip(amount, currency)
+        ]
+        return pd.Series(rounded_values, index=amount.index)
+
     @abstractmethod
     def price_history(self) -> pd.DataFrame:
         """Retrieves a data frame with all price definitions.

--- a/tests/test_standalone_ledger.py
+++ b/tests/test_standalone_ledger.py
@@ -139,64 +139,55 @@ def test_validate_account_balance(account: int, expected_length: int, expected_b
     assert len(ledger.account_history(account)) == expected_length
     assert ledger.account_balance(account)["CHF"] == expected_balance
 
-@pytest.mark.parametrize(
-    "amounts, currencies, expected",
-    [
-        (
-            pd.Series([100.234, 200.567, 300.891]),
-            pd.Series(["USD", "EUR", "GBP"]),
-            pd.Series([100.23, 200.57, 300.89])
-        ),
-        (
-            pd.Series([0.0, 0.0, 0.0]),
-            pd.Series(["USD", "EUR", "GBP"]),
-            pd.Series([0.0, 0.0, 0.0])
-        ),
-        (
-            pd.Series([123456.789, 987654.321, 111111.111]),
-            pd.Series(["USD", "EUR", "GBP"]),
-            pd.Series([123456.79, 987654.32, 111111.11])
-        ),
-        (
-            pd.Series([100.234, 200.567, 300.891, 400.789]),
-            pd.Series(["USD", "CHF", "CAD", "HKD"]),
-            pd.Series([100.23, 200.57, 300.89, 400.79])
-        ),
-    ]
-)
-def test_rounding(amounts, currencies, expected):
+
+@pytest.fixture
+def ledger():
+    PRECISION = {
+        "CHF": 0.01,
+        "USD": 0.01,
+        "EUR": 0.01,
+        "GBP": 0.01,
+        "JPY": 1.0,
+    }
+
     ledger = TestLedger()
-    result = ledger.round_series_to_precision(amounts, currencies)
-    pd.testing.assert_series_equal(result, expected)
+    ledger._settings["precision"] = PRECISION
+    return ledger
 
-@pytest.mark.parametrize(
-    "amounts, currencies, expected",
-    [
-        (
-            pd.Series([100.234, pd.NA, 300.891]),
-            pd.Series(["USD", "EUR", "GBP"]),
-            pd.Series([100.23, pd.NA, 300.89])
-        ),
-        (
-            pd.Series([pd.NA, pd.NA, pd.NA]),
-            pd.Series(["USD", "EUR", "GBP"]),
-            pd.Series([pd.NA, pd.NA, pd.NA])
-        ),
-    ]
-)
-def test_rounding_with_nan(amounts, currencies, expected):
-    ledger = TestLedger()
-    result = ledger.round_series_to_precision(amounts, currencies)
-    pd.testing.assert_series_equal(result, expected)
 
-def test_rounding_with_different_precision():
-    ledger = TestLedger()
-    # Assuming a different precision setting, which might be manually set for the test
-    ledger._settings["precision"]["JPY"] = 1.0  # Example precision for JPY
+def test_rounding(ledger):
+    result = ledger.round_to_precision([100.234, 300.891], ["USD", "GBP"])
+    assert result == [100.23, 300.89], "Rounding failed."
 
-    amounts = pd.Series([100.234, 200.567, 300.891])
-    currencies = pd.Series(["USD", "JPY", "GBP"])
-    expected = pd.Series([100.23, 201.0, 300.89])
 
-    result = ledger.round_series_to_precision(amounts, currencies)
-    pd.testing.assert_series_equal(result, expected)
+def test_rounding_with_nan(ledger):
+    result = ledger.round_to_precision([100.234, None, 300.891], ["USD", "EUR", "GBP"])
+    assert result == [100.23, None, 300.89], "Rounding with None failed."
+
+
+def test_rounding_with_different_precision(ledger):
+    result = ledger.round_to_precision([100.234, 200.567, 300.891], ["USD", "JPY", "GBP"])
+    assert result == [100.23, 201.0, 300.89], "Rounding with mixed precision failed."
+
+
+def test_arguments_of_differing_length_raises_error(ledger):
+    with pytest.raises(ValueError, match="Amount and ticker lists must be of the same length"):
+        ledger.round_to_precision([100.234, 200.567], ["USD"])
+
+
+def test_rounding_with_scalar_amount_and_ticker(ledger):
+    result = ledger.round_to_precision(100.234, "USD")
+    assert result == 100.23, "Rounding scalar amount failed."
+
+
+def test_rounding_with_list_amount_and_scalar_ticker(ledger):
+    result = ledger.round_to_precision([100.234, 200.567, 300.891], "USD")
+    assert result == [100.23, 200.57, 300.89], "Rounding scalar ticker failed."
+
+def test_rounding_with_empty_ticker(ledger):
+    with pytest.raises(KeyError):
+        ledger.round_to_precision([100.234], [""])
+
+def test_rounding_with_unknown_ticker(ledger):
+    with pytest.raises(KeyError):
+        ledger.round_to_precision([100.234], ["XYZ"])


### PR DESCRIPTION
### This PR introduces the `round_series_to_precision()` method, which is necessary for implementing [issue #35](https://github.com/macxred/cashctrl_ledger/issues/35).

Key points:

- Python does not natively support method overloading, so instead of overloading the existing `round_to_precision()` method, I created a new method, `round_series_to_precision()`, for the vectorized version. This avoids adding type checks and splitting the logic within a single method.
- The tests are currently written under the `TestLedger()` class. These tests are expected to be refactored in [milestone #2](https://github.com/macxred/pyledger/milestone/2).

@lasuk Please review the changes and provide feedback or approval for merging