### PR TITLE
Feat: move txn_to_str() to ledger engine

### DIFF
--- a/pyledger/ledger_engine.py
+++ b/pyledger/ledger_engine.py
@@ -1066,7 +1066,7 @@ class LedgerEngine(ABC):
             raise ValueError("Some collective transaction(s) have non-unique date.")
 
         result = {
-            str(ledger_id): f"{str(date)},{df_to_consistent_str(txn)}"
+            str(ledger_id): f"{str(date)}\n{df_to_consistent_str(txn)}"
             for ledger_id, date, txn in zip(df["id"], df["date"], df["txn"])
         }
         return result

--- a/pyledger/ledger_engine.py
+++ b/pyledger/ledger_engine.py
@@ -1049,21 +1049,21 @@ class LedgerEngine(ABC):
     def txn_to_str(self, df: pd.DataFrame) -> List[str]:
         """Create a consistent, unique representation of ledger transactions.
 
-        This method converts each transaction into a string format and stores
-        them in a list. The result can be used to compare transactions, ensuring
-        consistency and uniqueness.
+        This method converts each transaction into a CSV-like string format and stores
+        them in a list. The result can be used to compare transactions, ensuring consistency
+        and uniqueness.
 
         Args:
             df (pd.DataFrame): The DataFrame containing ledger transactions.
 
         Returns:
-            List[str]: A sorted list of unique strings, where each entry represents
-            a transaction.
+            List[str]: A list of unique strings in a CSV-like format.
         """
         df = nest(df, columns=[col for col in df.columns if col not in ["id", "date"]], key="txn")
         df = df.drop(columns=["id"])
         result = [
-            f"{str(date)},{df_to_consistent_str(txn)}" for date, txn in zip(df["date"], df["txn"])
+            f"{str(date)},{df_to_consistent_str(txn)}"
+            for date, txn in zip(df["date"], df["txn"])
         ]
         result.sort()
         return result

--- a/pyledger/ledger_engine.py
+++ b/pyledger/ledger_engine.py
@@ -1069,7 +1069,7 @@ class LedgerEngine(ABC):
             str(ledger_id): f"{str(date)},{df_to_consistent_str(txn)}"
             for ledger_id, date, txn in zip(df["id"], df["date"], df["txn"])
         }
-        return dict(sorted(result.items()))
+        return result
 
     # ----------------------------------------------------------------------
     # Currency

--- a/tests/base_test_dump_restore.py
+++ b/tests/base_test_dump_restore.py
@@ -64,7 +64,8 @@ class BaseTestDumpAndRestore(ABC):
         assert_frame_equal(
             ledger.standardize_account_chart(ACCOUNTS), ledger.account_chart(), ignore_index=True
         )
-        assert ledger.txn_to_str(ledger.standardize_ledger(LEDGER_ENTRIES)) == ledger.txn_to_str(ledger.ledger())
+        expected_ledger = ledger.txn_to_str(ledger.standardize_ledger(LEDGER_ENTRIES))
+        assert expected_ledger == ledger.txn_to_str(ledger.ledger())
 
     def test_dump_and_restore_zip(self, ledger, tmp_path, restore_initial_state):
         # Populate with test data

--- a/tests/base_test_dump_restore.py
+++ b/tests/base_test_dump_restore.py
@@ -64,8 +64,11 @@ class BaseTestDumpAndRestore(ABC):
         assert_frame_equal(
             ledger.standardize_account_chart(ACCOUNTS), ledger.account_chart(), ignore_index=True
         )
-        expected_ledger = ledger.txn_to_str(ledger.standardize_ledger(LEDGER_ENTRIES))
-        assert expected_ledger == ledger.txn_to_str(ledger.ledger())
+        expected_ledger = sorted(
+            ledger.txn_to_str(ledger.standardize_ledger(LEDGER_ENTRIES)).values()
+        )
+        ledger = sorted(ledger.txn_to_str(ledger.ledger()).values())
+        assert expected_ledger == ledger
 
     def test_dump_and_restore_zip(self, ledger, tmp_path, restore_initial_state):
         # Populate with test data
@@ -86,4 +89,5 @@ class BaseTestDumpAndRestore(ABC):
         assert ledger.base_currency == "USD", "Base currency were not restored"
         assert_frame_equal(vat_codes, ledger.vat_codes(), ignore_index=True)
         assert_frame_equal(account_chart, ledger.account_chart(), ignore_index=True)
-        assert ledger.txn_to_str(ledger_entries) == ledger.txn_to_str(ledger.ledger())
+        assert sorted(ledger.txn_to_str(ledger_entries).values()) == \
+               sorted(ledger.txn_to_str(ledger.ledger()).values())

--- a/tests/base_test_ledger.py
+++ b/tests/base_test_ledger.py
@@ -267,7 +267,8 @@ class BaseTestLedger(ABC):
         ledger.mirror_ledger(target=target, delete=True)
         expected = ledger.standardize_ledger(target)
         mirrored = ledger.ledger()
-        assert ledger.txn_to_str(mirrored) == ledger.txn_to_str(expected)
+        assert sorted(ledger.txn_to_str(mirrored).values()) == \
+               sorted(ledger.txn_to_str(expected).values())
 
         # Mirror with duplicate transactions and delete=False
         target = pd.concat(
@@ -281,7 +282,8 @@ class BaseTestLedger(ABC):
         ledger.mirror_ledger(target=target, delete=True)
         expected = ledger.standardize_ledger(target)
         mirrored = ledger.ledger()
-        assert ledger.txn_to_str(mirrored) == ledger.txn_to_str(expected)
+        assert sorted(ledger.txn_to_str(mirrored).values()) == \
+               sorted(ledger.txn_to_str(expected).values())
 
         # Mirror with complex transactions and delete=False
         target = LEDGER_ENTRIES.query("id in [15, 16, 17, 18]")
@@ -290,20 +292,23 @@ class BaseTestLedger(ABC):
         expected = ledger.sanitize_ledger(expected)
         expected = pd.concat([mirrored, expected])
         mirrored = ledger.ledger()
-        assert ledger.txn_to_str(mirrored) == ledger.txn_to_str(expected)
+        assert sorted(ledger.txn_to_str(mirrored).values()) == \
+               sorted(ledger.txn_to_str(expected).values())
 
         # Mirror existing transactions with delete=False has no impact
         target = LEDGER_ENTRIES.query("id in [1, 2]")
         ledger.mirror_ledger(target=target, delete=False)
         mirrored = ledger.ledger()
-        assert ledger.txn_to_str(mirrored) == ledger.txn_to_str(expected)
+        assert sorted(ledger.txn_to_str(mirrored).values()) == \
+               sorted(ledger.txn_to_str(expected).values())
 
         # Mirror with delete=True
         target = LEDGER_ENTRIES.query("id in [1, 2]")
         ledger.mirror_ledger(target=target, delete=True)
         mirrored = ledger.ledger()
         expected = ledger.standardize_ledger(target)
-        assert ledger.txn_to_str(mirrored) == ledger.txn_to_str(expected)
+        assert sorted(ledger.txn_to_str(mirrored).values()) == \
+               sorted(ledger.txn_to_str(expected).values())
 
         # Mirror an empty target state
         ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -4,26 +4,8 @@ class.
 """
 
 import pytest
-import pandas as pd
-from io import StringIO
 from tests.base_test_ledger import BaseTestLedger
 from pyledger import MemoryLedger
-
-# flake8: noqa: E501
-LEDGER_CSV = """
-    id,     date, account, counter_account, currency,     amount, base_currency_amount,      vat_code, text,                             document
-    1,  2024-05-24, 10023,           19993,      CHF,     100.00,                     , Test_VAT_code, pytest single transaction 1,      /file1.txt
-    2,  2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2,  2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2,  2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
-    3,  2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
-    3,  2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
-    4,  2024-05-25, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
-"""
-
-# flake8: enable
-
-LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 
 
 class TestLedger(BaseTestLedger):
@@ -31,86 +13,3 @@ class TestLedger(BaseTestLedger):
     @pytest.fixture
     def ledger(self):
         return MemoryLedger()
-
-    def test_txn_to_str(self):
-        ledger = MemoryLedger()
-        df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 2])]
-        result = ledger.txn_to_str(df)
-        # flake8: noqa: E501
-        expected = {
-            '1': (
-                "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
-            ),
-            '2': (
-                "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10022,-100.0,-88.88,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
-                "10022,1.0,0.89,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
-                "10022,99.0,87.99,,USD,,pytest collective txn 1 - line 1,Test_VAT_code"
-            )
-        }
-        # flake8: enable
-        assert result == expected, "Transactions were not converted correctly."
-
-    def test_txn_to_str_transactions_by_id(self):
-        ledger = MemoryLedger()
-        df = LEDGER_ENTRIES
-        result = ledger.txn_to_str(df)
-        # flake8: noqa: E501
-        expected_first_txn = (
-            "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-            "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
-        )
-        expected_last_txn = (
-            "2024-05-25,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-            "10022,300.0,450.45,19992,USD,/document-alt.pdf,pytest single transaction 2,Test_VAT_code"
-        )
-        # flake8: enable
-
-        assert result["1"] == expected_first_txn, (
-            "The transaction with key '1' does not match the expected value."
-        )
-        assert result["4"] == expected_last_txn, (
-            "The transaction with key '4' does not match the expected value."
-        )
-
-    def test_txn_to_str_empty_df(self):
-        ledger = MemoryLedger()
-        df = pd.DataFrame(columns=LEDGER_ENTRIES.columns)
-        result = ledger.txn_to_str(df)
-        assert result == {}, "Empty DataFrame did not return an empty dict."
-
-    def test_txn_to_str_different_representations(self):
-        ledger = MemoryLedger()
-        df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
-        df2 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 4]
-        result1 = ledger.txn_to_str(df1)
-        result2 = ledger.txn_to_str(df2)
-        assert result1 != result2, "Different transactions should have different string representations."
-
-    def test_txn_to_str_non_unique_dates(self):
-        ledger = MemoryLedger()
-        df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 4])]
-        df.loc[df["id"] == 4, "id"] = 1
-        with pytest.raises(ValueError):
-            ledger.txn_to_str(df)
-
-    def test_txn_to_str_same_transactions_different_order_dtypes(self):
-        ledger = MemoryLedger()
-        df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
-        # Reverse the column order
-        df2 = df1[df1.columns[::-1]]
-        # DataFrame with shuffled rows
-        df3 = df1.sample(frac=1).reset_index(drop=True)  # Shuffle the rows
-        # DataFrame with different dtypes (e.g., convert 'amount' to string, 'account' to float)
-        df4 = df1.copy()
-        df4["amount"] = df4["amount"].astype(str)
-        df4["account"] = df4["account"].astype(float)
-
-        result1 = ledger.txn_to_str(df1)
-        result2 = ledger.txn_to_str(df2)
-        result3 = ledger.txn_to_str(df3)
-        result4 = ledger.txn_to_str(df4)
-        assert result1 == result2 == result3 == result4, (
-            "Same transactions should have identical string representations."
-        )

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -18,14 +18,12 @@ LEDGER_CSV = """
     2,  2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
     3,  2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
     3,  2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
-    4,  2024-05-24, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+    4,  2024-05-25, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
 """
+
 # flake8: enable
 
-STRIPPED_CSV = "\n".join([line.strip() for line in LEDGER_CSV.split("\n")])
-LEDGER_ENTRIES = pd.read_csv(
-    StringIO(STRIPPED_CSV), skipinitialspace=True, comment="#", skip_blank_lines=True
-)
+LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 
 
 class TestLedger(BaseTestLedger):
@@ -39,18 +37,18 @@ class TestLedger(BaseTestLedger):
         df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 2])]
         result = ledger.txn_to_str(df)
         # flake8: noqa: E501
-        expected = [
-            (
+        expected = {
+            '1': (
                 "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10022.0,-100.0,-88.88,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
-                "10022.0,1.0,0.89,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
-                "10022.0,99.0,87.99,,USD,,pytest collective txn 1 - line 1,Test_VAT_code"
+                "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
             ),
-            (
+            '2': (
                 "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10023.0,100.0,,19993.0,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+                "10022,-100.0,-88.88,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
+                "10022,1.0,0.89,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
+                "10022,99.0,87.99,,USD,,pytest collective txn 1 - line 1,Test_VAT_code"
             )
-        ]
+        }
         # flake8: enable
         assert result == expected, "Transactions were not converted correctly."
 
@@ -60,24 +58,23 @@ class TestLedger(BaseTestLedger):
             result = ledger.txn_to_str(df)
             # flake8: noqa: E501
             expected_first_txn = (
-                "2024-04-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10021.0,200.0,175.55,,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 2,Test_VAT_code\n"
-                ",200.0,175.55,10021.0,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 1,Test_VAT_code"
-            )
-            expected_last_txn = (
                 "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10023.0,100.0,,19993.0,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+                "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+            )
+
+            expected_last_txn = (
+                "2024-05-25,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+                "10022,300.0,450.45,19992,USD,/document-alt.pdf,pytest single transaction 2,Test_VAT_code"
             )
             # flake8: enable
-            assert result[0] == expected_first_txn, "First transaction was not sorted correctly."
-            assert result[-1] == expected_last_txn, "Last transaction was not sorted correctly."
+            assert result["1"] == expected_first_txn, "First transaction was not sorted correctly."
+            assert result["4"] == expected_last_txn, "Last transaction was not sorted correctly."
 
     def test_txn_to_str_empty_df(self):
         ledger = MemoryLedger()
         df = pd.DataFrame(columns=LEDGER_ENTRIES.columns)
         result = ledger.txn_to_str(df)
-        expected = []
-        assert result == expected, "Empty DataFrame did not return an empty list."
+        assert result == {}, "Empty DataFrame did not return an empty dict."
 
     def test_txn_to_str_different_representations(self):
         ledger = MemoryLedger()
@@ -86,3 +83,30 @@ class TestLedger(BaseTestLedger):
         result1 = ledger.txn_to_str(df1)
         result2 = ledger.txn_to_str(df2)
         assert result1 != result2, "Different transactions should have different string representations."
+
+    def test_txn_to_str_non_unique_dates(self):
+        ledger = MemoryLedger()
+        df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 4])]
+        df.loc[df["id"] == 4, "id"] = 1
+        with pytest.raises(ValueError):
+            ledger.txn_to_str(df)
+
+    def test_txn_to_str_same_transactions_different_order_dtypes(self):
+        ledger = MemoryLedger()
+        df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
+        # Reverse the column order
+        df2 = df1[df1.columns[::-1]]
+        # DataFrame with shuffled rows
+        df3 = df1.sample(frac=1).reset_index(drop=True)  # Shuffle the rows
+        # DataFrame with different dtypes (e.g., convert 'amount' to string, 'account' to float)
+        df4 = df1.copy()
+        df4["amount"] = df4["amount"].astype(str)
+        df4["account"] = df4["account"].astype(float)
+
+        result1 = ledger.txn_to_str(df1)
+        result2 = ledger.txn_to_str(df2)
+        result3 = ledger.txn_to_str(df3)
+        result4 = ledger.txn_to_str(df4)
+        assert result1 == result2 == result3 == result4, (
+            "Same transactions should have identical string representations."
+        )

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -52,23 +52,27 @@ class TestLedger(BaseTestLedger):
         # flake8: enable
         assert result == expected, "Transactions were not converted correctly."
 
-    def test_txn_to_str_sorted_transactions(self):
-            ledger = MemoryLedger()
-            df = LEDGER_ENTRIES
-            result = ledger.txn_to_str(df)
-            # flake8: noqa: E501
-            expected_first_txn = (
-                "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
-            )
+    def test_txn_to_str_transactions_by_id(self):
+        ledger = MemoryLedger()
+        df = LEDGER_ENTRIES
+        result = ledger.txn_to_str(df)
+        # flake8: noqa: E501
+        expected_first_txn = (
+            "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+            "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+        )
+        expected_last_txn = (
+            "2024-05-25,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+            "10022,300.0,450.45,19992,USD,/document-alt.pdf,pytest single transaction 2,Test_VAT_code"
+        )
+        # flake8: enable
 
-            expected_last_txn = (
-                "2024-05-25,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-                "10022,300.0,450.45,19992,USD,/document-alt.pdf,pytest single transaction 2,Test_VAT_code"
-            )
-            # flake8: enable
-            assert result["1"] == expected_first_txn, "First transaction was not sorted correctly."
-            assert result["4"] == expected_last_txn, "Last transaction was not sorted correctly."
+        assert result["1"] == expected_first_txn, (
+            "The transaction with key '1' does not match the expected value."
+        )
+        assert result["4"] == expected_last_txn, (
+            "The transaction with key '4' does not match the expected value."
+        )
 
     def test_txn_to_str_empty_df(self):
         ledger = MemoryLedger()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,11 +1,31 @@
-"""This module contains the test suite for VAT code operations using the MemoryLedger
-implementation. It inherits the common VAT code tests from the BaseTestVatCode abstract base
+"""This module contains the test suite for Ledger entries operations using the MemoryLedger
+implementation. It inherits the common Ledger code tests from the BaseTestLedger abstract base
 class.
 """
 
 import pytest
+import pandas as pd
+from io import StringIO
 from tests.base_test_ledger import BaseTestLedger
 from pyledger import MemoryLedger
+
+# flake8: noqa: E501
+LEDGER_CSV = """
+    id,     date, account, counter_account, currency,     amount, base_currency_amount,      vat_code, text,                             document
+    1,  2024-05-24, 10023,           19993,      CHF,     100.00,                     , Test_VAT_code, pytest single transaction 1,      /file1.txt
+    2,  2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2,  2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2,  2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
+    3,  2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+    3,  2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
+    4,  2024-05-24, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+"""
+# flake8: enable
+
+STRIPPED_CSV = "\n".join([line.strip() for line in LEDGER_CSV.split("\n")])
+LEDGER_ENTRIES = pd.read_csv(
+    StringIO(STRIPPED_CSV), skipinitialspace=True, comment="#", skip_blank_lines=True
+)
 
 
 class TestLedger(BaseTestLedger):
@@ -13,3 +33,56 @@ class TestLedger(BaseTestLedger):
     @pytest.fixture
     def ledger(self):
         return MemoryLedger()
+
+    def test_txn_to_str(self):
+        ledger = MemoryLedger()
+        df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 2])]
+        result = ledger.txn_to_str(df)
+        # flake8: noqa: E501
+        expected = [
+            (
+                "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+                "10022.0,-100.0,-88.88,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
+                "10022.0,1.0,0.89,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
+                "10022.0,99.0,87.99,,USD,,pytest collective txn 1 - line 1,Test_VAT_code"
+            ),
+            (
+                "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+                "10023.0,100.0,,19993.0,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+            )
+        ]
+        # flake8: enable
+        assert result == expected, "Transactions were not converted correctly."
+
+    def test_txn_to_str_sorted_transactions(self):
+            ledger = MemoryLedger()
+            df = LEDGER_ENTRIES
+            result = ledger.txn_to_str(df)
+            # flake8: noqa: E501
+            expected_first_txn = (
+                "2024-04-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+                "10021.0,200.0,175.55,,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 2,Test_VAT_code\n"
+                ",200.0,175.55,10021.0,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 1,Test_VAT_code"
+            )
+            expected_last_txn = (
+                "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+                "10023.0,100.0,,19993.0,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+            )
+            # flake8: enable
+            assert result[0] == expected_first_txn, "First transaction was not sorted correctly."
+            assert result[-1] == expected_last_txn, "Last transaction was not sorted correctly."
+
+    def test_txn_to_str_empty_df(self):
+        ledger = MemoryLedger()
+        df = pd.DataFrame(columns=LEDGER_ENTRIES.columns)
+        result = ledger.txn_to_str(df)
+        expected = []
+        assert result == expected, "Empty DataFrame did not return an empty list."
+
+    def test_txn_to_str_different_representations(self):
+        ledger = MemoryLedger()
+        df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
+        df2 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 4]
+        result1 = ledger.txn_to_str(df1)
+        result2 = ledger.txn_to_str(df2)
+        assert result1 != result2, "Different transactions should have different string representations."

--- a/tests/test_txn_to_str.py
+++ b/tests/test_txn_to_str.py
@@ -1,0 +1,99 @@
+"""This module contains the test suite for Ledger entries operations using the MemoryLedger
+implementation. It inherits the common Ledger code tests from the BaseTestLedger abstract base
+class.
+"""
+
+import pytest
+import pandas as pd
+from io import StringIO
+from tests.base_test_ledger import BaseTestLedger
+from pyledger import MemoryLedger
+
+# flake8: noqa: E501
+LEDGER_CSV = """
+    id,     date, account, counter_account, currency,     amount, base_currency_amount,      vat_code, text,                             document
+    1,  2024-05-24, 10023,           19993,      CHF,     100.00,                     , Test_VAT_code, pytest single transaction 1,      /file1.txt
+    2,  2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2,  2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2,  2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
+    3,  2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+    3,  2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
+    4,  2024-05-25, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+"""
+EXPECTED = {
+    '1': (
+        "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+    ),
+    '2': (
+        "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "10022,-100.0,-88.88,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
+        "10022,1.0,0.89,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
+        "10022,99.0,87.99,,USD,,pytest collective txn 1 - line 1,Test_VAT_code"
+    ),
+    '3': (
+        "2024-04-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "10021,200.0,175.55,,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 2,Test_VAT_code\n"
+        ",200.0,175.55,10021,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 1,Test_VAT_code"
+    ),
+    '4': (
+        "2024-05-25,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "10022,300.0,450.45,19992,USD,/document-alt.pdf,pytest single transaction 2,Test_VAT_code"
+    )
+}
+# flake8: enable
+
+LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
+
+
+def test_txn_to_str():
+    ledger = MemoryLedger()
+    result = ledger.txn_to_str(LEDGER_ENTRIES)
+    assert result == EXPECTED, "Transactions were not converted correctly."
+
+
+def test_txn_to_str_empty_df():
+    ledger = MemoryLedger()
+    df = pd.DataFrame(columns=LEDGER_ENTRIES.columns)
+    result = ledger.txn_to_str(df)
+    assert result == {}, "Empty DataFrame did not return an empty dict."
+
+
+def test_txn_to_str_different_representations():
+    ledger = MemoryLedger()
+    df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
+    df2 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 4]
+    result1 = ledger.txn_to_str(df1)
+    result2 = ledger.txn_to_str(df2)
+    assert result1 != result2, (
+        "Different transactions should have different string representations."
+    )
+
+
+def test_txn_to_str_non_unique_dates():
+    ledger = MemoryLedger()
+    df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 4])]
+    df.loc[df["id"] == 4, "id"] = 1
+    with pytest.raises(ValueError):
+        ledger.txn_to_str(df)
+
+
+def test_txn_to_str_same_transactions_different_order_dtypes():
+    ledger = MemoryLedger()
+    df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
+    # Reverse the column order
+    df2 = df1[df1.columns[::-1]]
+    # DataFrame with shuffled rows
+    df3 = df1.sample(frac=1).reset_index(drop=True)  # Shuffle the rows
+    # DataFrame with different dtypes (e.g., convert 'amount' to string, 'account' to float)
+    df4 = df1.copy()
+    df4["amount"] = df4["amount"].astype(str)
+    df4["account"] = df4["account"].astype(float)
+
+    result1 = ledger.txn_to_str(df1)
+    result2 = ledger.txn_to_str(df2)
+    result3 = ledger.txn_to_str(df3)
+    result4 = ledger.txn_to_str(df4)
+    assert result1 == result2 == result3 == result4, (
+        "Same transactions should have identical string representations."
+    )

--- a/tests/test_txn_to_str.py
+++ b/tests/test_txn_to_str.py
@@ -59,17 +59,6 @@ def test_txn_to_str_empty_df():
     assert result == {}, "Empty DataFrame did not return an empty dict."
 
 
-def test_txn_to_str_different_representations():
-    ledger = MemoryLedger()
-    df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
-    df2 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 4]
-    result1 = ledger.txn_to_str(df1)
-    result2 = ledger.txn_to_str(df2)
-    assert result1 != result2, (
-        "Different transactions should have different string representations."
-    )
-
-
 def test_txn_to_str_non_unique_dates():
     ledger = MemoryLedger()
     df = LEDGER_ENTRIES[LEDGER_ENTRIES["id"].isin([1, 4])]

--- a/tests/test_txn_to_str.py
+++ b/tests/test_txn_to_str.py
@@ -68,22 +68,26 @@ def test_txn_to_str_non_unique_dates():
         ledger.txn_to_str(df)
 
 
-def test_txn_to_str_same_transactions_different_order_dtypes():
+def test_txn_to_str_variations_of_same_transactions():
     ledger = MemoryLedger()
     df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 2]
     # Reverse the column order
     df2 = df1[df1.columns[::-1]]
-    # DataFrame with shuffled rows
+    # Shuffle rows
     df3 = df1.sample(frac=1).reset_index(drop=True)  # Shuffle the rows
-    # DataFrame with different dtypes (e.g., convert 'amount' to string, 'account' to float)
+    # Change dtypes
     df4 = df1.copy()
     df4["amount"] = df4["amount"].astype(str)
     df4["account"] = df4["account"].astype(float)
+    # Replace column short column name by full name
+    df5 = df1.copy()
+    df5 = df5.rename(columns={"base_currency": "base_currency_amount"})
 
     result1 = ledger.txn_to_str(df1)
     result2 = ledger.txn_to_str(df2)
     result3 = ledger.txn_to_str(df3)
     result4 = ledger.txn_to_str(df4)
-    assert result1 == result2 == result3 == result4, (
+    result5 = ledger.txn_to_str(df5)
+    assert result1 == result2 == result3 == result4 == result5, (
         "Same transactions should have identical string representations."
     )

--- a/tests/test_txn_to_str.py
+++ b/tests/test_txn_to_str.py
@@ -69,7 +69,7 @@ def test_txn_to_str_non_unique_dates():
 
 def test_txn_to_str_same_transactions_different_order_dtypes():
     ledger = MemoryLedger()
-    df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 1]
+    df1 = LEDGER_ENTRIES[LEDGER_ENTRIES["id"] == 2]
     # Reverse the column order
     df2 = df1[df1.columns[::-1]]
     # DataFrame with shuffled rows

--- a/tests/test_txn_to_str.py
+++ b/tests/test_txn_to_str.py
@@ -6,42 +6,43 @@ class.
 import pytest
 import pandas as pd
 from io import StringIO
-from tests.base_test_ledger import BaseTestLedger
 from pyledger import MemoryLedger
 
-# flake8: noqa: E501
 LEDGER_CSV = """
-    id,     date, account, counter_account, currency,     amount, base_currency_amount,      vat_code, text,                             document
-    1,  2024-05-24, 10023,           19993,      CHF,     100.00,                     , Test_VAT_code, pytest single transaction 1,      /file1.txt
-    2,  2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2,  2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2,  2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
-    3,  2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
-    3,  2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
-    4,  2024-05-25, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+    id,   date, account, counter, currency,  amount, base_amount,  vat, text,          document
+    1, 2024-05-24, 1023,    1993,      CHF,  100.00,            , In8%, single txn 1,  file1.txt
+    2, 2024-05-24, 1022,        ,      USD,    1.00,        0.89,     , collective 1,  dir/file.txt
+    2, 2024-05-24, 1022,        ,      USD,   99.00,       87.99,     , collective 1,
+    2, 2024-05-24, 1022,        ,      USD, -100.00,      -88.88, In5%, collective 1,  dir/file.txt
+    3, 2024-04-24,     ,    1021,      EUR,  200.00,            , In5%, collective 2A, doc1.pdf
+    3, 2024-04-24, 1021,        ,      EUR,  200.00,            ,     , collective 2B, doc2.pdf
+    4, 2024-05-25, 1022,    1992,      USD,  300.00,      450.45, In2%, single txn 2,  doc3.pdf
 """
 EXPECTED = {
     '1': (
-        "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-        "10023,100.0,,19993,CHF,/file1.txt,pytest single transaction 1,Test_VAT_code"
+        "2024-05-24\n"
+        "account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "1023,100.0,,1993,CHF,file1.txt,single txn 1,In8%"
     ),
     '2': (
-        "2024-05-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-        "10022,-100.0,-88.88,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
-        "10022,1.0,0.89,,USD,/subdir/file2.txt,pytest collective txn 1 - line 1,Test_VAT_code\n"
-        "10022,99.0,87.99,,USD,,pytest collective txn 1 - line 1,Test_VAT_code"
+        "2024-05-24\n"
+        "account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "1022,-100.0,-88.88,,USD,dir/file.txt,collective 1,In5%\n"
+        "1022,1.0,0.89,,USD,dir/file.txt,collective 1,\n"
+        "1022,99.0,87.99,,USD,,collective 1,"
     ),
     '3': (
-        "2024-04-24,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-        "10021,200.0,175.55,,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 2,Test_VAT_code\n"
-        ",200.0,175.55,10021,EUR,/document-col-alt.pdf,pytest collective txn 2 - line 1,Test_VAT_code"
+        "2024-04-24\n"
+        "account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "1021,200.0,,,EUR,doc2.pdf,collective 2B,\n"
+        ",200.0,,1021,EUR,doc1.pdf,collective 2A,In5%"
     ),
     '4': (
-        "2024-05-25,account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
-        "10022,300.0,450.45,19992,USD,/document-alt.pdf,pytest single transaction 2,Test_VAT_code"
+        "2024-05-25\n"
+        "account,amount,base_currency_amount,counter_account,currency,document,text,vat_code\n"
+        "1022,300.0,450.45,1992,USD,doc3.pdf,single txn 2,In2%"
     )
 }
-# flake8: enable
 
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 


### PR DESCRIPTION
**Summary of Changes:**
- Moved the `txn_to_str()` method to the `LedgerEngine` class to provide a consistent, unique representation of ledger transactions in CSV-like string format.
- Updated the method to ensure that both single and collective transactions are correctly represented and sortable for comparison.
- Created comprehensive test cases for `txn_to_str()`

@lasuk Please review the changes and provide feedback or approval for merging.