### PR TITLE
Add First Version of Integration Tests

### DIFF
--- a/pyledger/ledger_engine.py
+++ b/pyledger/ledger_engine.py
@@ -1090,6 +1090,7 @@ class LedgerEngine(ABC):
         # Fill missing (NA) dates
         df["date"] = df.groupby("id")["date"].ffill()
         df["date"] = df.groupby("id")["date"].bfill()
+        df["date"] = df["date"].dt.tz_localize(None).dt.floor('D')
 
         # Drop redundant report_amount for transactions in reporting currency
         set_na = (

--- a/pyledger/ledger_engine.py
+++ b/pyledger/ledger_engine.py
@@ -621,11 +621,13 @@ class LedgerEngine(ABC):
                 for currency in (at_start | at_end).keys()
             }
 
-        result = {
-            ticker: self.round_to_precision(value, ticker=ticker, date=date)
-            for ticker, value in result.items()
-        }
-
+        # Type consistent return value Dict[str, float]
+        def _standardize_currency(ticker: str, x: float) -> float:
+            result = float(self.round_to_precision(x, ticker=ticker, date=date))
+            if result == -0.0:
+                result = 0.0
+            return result
+        result = {k: _standardize_currency(k, v) for k, v in result.items()}
         return result
 
     def account_history(

--- a/pyledger/standalone_ledger.py
+++ b/pyledger/standalone_ledger.py
@@ -408,7 +408,7 @@ class StandaloneLedger(LedgerEngine):
         df = self.serialized_ledger()
         rows = df["account"] == int(account)
         if date is not None:
-            rows = rows & (df["date"] <= date)
+            rows = rows & (df["date"] <= pd.Timestamp(date))
         cols = ["amount", "report_amount", "currency"]
         if rows.sum() == 0:
             result = {"reporting_currency": 0.0}

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -49,7 +49,7 @@ LEDGER_CSV = """
      4, 2024-05-25,    1010,   5000,      EUR,     -800.00,              ,   IN_STD, Purchase goods, 2024/payables/2024-05-25.pdf
      5, 2024-05-05,    1000,   5000,      USD,     -555.55,              ,   IN_STD, Purchase with tax, 2024/payables/2024-05-05.pdf
      6, 2024-05-06,    1000,   5000,      USD,     -666.66,              ,   IN_RED, Purchase at reduced tax, 2024/payables/2024-05-06.pdf
-     7, 2024-05-07,    1000,       ,      USD,     -777.77,              ,   EXEMPT, Tax-Exempt purchase, 2024/payables/2024-05-07.pdf
+     7, 2024-05-07,    1000,   5000,      USD,     -777.77,              ,   EXEMPT, Tax-Exempt purchase, 2024/payables/2024-05-07.pdf
      8, 2024-05-08,    1000,       ,      USD,     -888.88,              ,         , Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
      8,           ,        ,   5000,      USD,     -555.55,              ,   IN_STD, Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
      8,           ,        ,   5000,      USD,     -444.44,              ,   EXEMPT, Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
@@ -62,8 +62,8 @@ LEDGER_CSV = """
     12, 2024-08-07,    1000,   2000,      USD,     -200.00,              ,         , Payment to supplier,
     13, 2024-08-08,    2000,   1000,      USD,     1000.00,              ,         , Correction of previous entry,
     14, 2024-08-08,    1010,   2010,      EUR,        0.00,              ,         , Zero amount transaction,
-    15, 2024-05-24,    1000,       ,      USD,      100.00,              ,  OUT_RED, Collective transaction with zero amount,
-    15,           ,    1000,       ,      USD,     -100.00,              ,  OUT_RED, Collective transaction with zero amount,
+    15, 2024-05-24,    1000,       ,      USD,      100.00,              ,         , Collective transaction with zero amount,
+    15,           ,    1000,       ,      USD,     -100.00,              ,         , Collective transaction with zero amount,
     15,           ,    1000,       ,      USD,        0.00,              ,         , Collective transaction with zero amount,
     16, 2024-05-24,    1000,   1005,      USD,      100.00,              ,         , Collective transaction - leg with debit and credit account,
     16,           ,    1010,       ,      EUR,       20.00,         20.50,         , Collective transaction - leg with credit account,

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -124,19 +124,20 @@ REVALUATION_CSV = """
 """
 REVALUATION = pd.read_csv(StringIO(REVALUATION_CSV), skipinitialspace=True)
 
+# flake8: noqa: E501
 EXPECTED_BALANCE_CSV = """
     date,         account, balance
     2023-12-31, 1000:9999, "{reporting_currency: 0.0, USD: 0.0, EUR: 0.0, JPY: 0.0}"
-    2024-01-01, 1000:9999, "{reporting_currency: 0.0, USD: 0.0, EUR: 0.0, JPY: 0.0}"
-    2024-01-01,      1000, "{reporting_currency: 800000.00, USD: 800000.0}"
-    2024-01-01,      1010, "{reporting_currency:    132.82, EUR:    120.0}"
-    2024-01-01,      1020, "{reporting_currency: 298200.00, JPY: 298200.0}"
+    2024-01-01, 1000:9999, "{reporting_currency: 0.0, USD: -298332.82, EUR: 120.0, JPY: 42000000.0}"
+    2024-01-01,      1000, "{reporting_currency: 800000.00, USD:   800000.00}"
+    2024-01-01,      1010, "{reporting_currency:    132.82, EUR:      120.00}"
+    2024-01-01,      1020, "{reporting_currency: 298200.00, JPY: 42000000.00}"
 """
 EXPECTED_BALANCE = pd.read_csv(StringIO(EXPECTED_BALANCE_CSV), skipinitialspace=True)
 EXPECTED_BALANCE["balance"] = (EXPECTED_BALANCE["balance"]
                                .str.replace(r'(\w+):', r'"\1":', regex=True)
                                .apply(json.loads))
-
+# flake8: enable
 
 class BaseTest(ABC):
     SETTINGS = {"REPORTING_CURRENCY": "USD"}

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -101,9 +101,33 @@ ASSETS_CSV = """
 """
 ASSETS = pd.read_csv(StringIO(ASSETS_CSV), skipinitialspace=True)
 
+PRICES_CSV = """
+          date, ticker,  price, currency
+    2023-12-29,    EUR, 1.1068, USD
+    2024-03-29,    EUR, 1.0794, USD
+    2024-06-28,    EUR, 1.0708, USD
+    2024-09-30,    EUR, 1.1170, USD
+    2023-12-29,    JPY, 0.0071, USD
+    2024-03-29,    JPY, 0.0066, USD
+    2024-06-28,    JPY, 0.0062, USD
+    2024-09-30,    JPY, 0.0070, USD
+"""
+PRICES = pd.read_csv(StringIO(PRICES_CSV), skipinitialspace=True)
+
+REVALUATION_CSV = """
+    date,         account, debit, credit, description
+    2024-03-31, 1000:2999,  7050,   8050, FX revaluations
+    2024-06-30, 1000:2999,  7050,       , FX revaluations
+    2024-09-30, 1000:2999,  7050,       , FX revaluations
+    2024-12-31, 1000:2999,  7050,       , FX revaluations
+"""
+REVALUATION = pd.read_csv(StringIO(REVALUATION_CSV), skipinitialspace=True)
+
 class BaseTest(ABC):
     SETTINGS = {"REPORTING_CURRENCY": "USD"}
     TAX_CODES = LedgerEngine.standardize_tax_codes(TAX_CODES)
     ACCOUNTS = LedgerEngine.standardize_accounts(ACCOUNTS)
     LEDGER_ENTRIES = LedgerEngine.standardize_ledger_columns(LEDGER)
     ASSETS = LedgerEngine.standardize_assets(ASSETS)
+    PRICES = LedgerEngine.standardize_price_df(PRICES)
+    REVALUATION = LedgerEngine.standardize_revaluations(REVALUATION)

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -1,5 +1,6 @@
 """Definition of abstract base class for testing."""
 
+import json
 import pandas as pd
 from abc import ABC
 from io import StringIO
@@ -123,6 +124,20 @@ REVALUATION_CSV = """
 """
 REVALUATION = pd.read_csv(StringIO(REVALUATION_CSV), skipinitialspace=True)
 
+EXPECTED_BALANCE_CSV = """
+    date,         account, balance
+    2023-12-31, 1000:9999, "{reporting_currency: 0.0, USD: 0.0, EUR: 0.0, JPY: 0.0}"
+    2024-01-01, 1000:9999, "{reporting_currency: 0.0, USD: 0.0, EUR: 0.0, JPY: 0.0}"
+    2024-01-01,      1000, "{reporting_currency: 800000.00, USD: 800000.0}"
+    2024-01-01,      1010, "{reporting_currency:    132.82, EUR:    120.0}"
+    2024-01-01,      1020, "{reporting_currency: 298200.00, JPY: 298200.0}"
+"""
+EXPECTED_BALANCE = pd.read_csv(StringIO(EXPECTED_BALANCE_CSV), skipinitialspace=True)
+EXPECTED_BALANCE["balance"] = (EXPECTED_BALANCE["balance"]
+                               .str.replace(r'(\w+):', r'"\1":', regex=True)
+                               .apply(json.loads))
+
+
 class BaseTest(ABC):
     SETTINGS = {"REPORTING_CURRENCY": "USD"}
     TAX_CODES = LedgerEngine.standardize_tax_codes(TAX_CODES)
@@ -131,3 +146,4 @@ class BaseTest(ABC):
     ASSETS = LedgerEngine.standardize_assets(ASSETS)
     PRICES = LedgerEngine.standardize_price_df(PRICES)
     REVALUATION = LedgerEngine.standardize_revaluations(REVALUATION)
+    EXPECTED_BALANCE = EXPECTED_BALANCE

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -115,23 +115,32 @@ PRICES_CSV = """
 """
 PRICES = pd.read_csv(StringIO(PRICES_CSV), skipinitialspace=True)
 
-REVALUATION_CSV = """
+REVALUATIONS_CSV = """
     date,         account, debit, credit, description
     2024-03-31, 1000:2999,  7050,   8050, FX revaluations
     2024-06-30, 1000:2999,  7050,       , FX revaluations
     2024-09-30, 1000:2999,  7050,       , FX revaluations
     2024-12-31, 1000:2999,  7050,       , FX revaluations
 """
-REVALUATION = pd.read_csv(StringIO(REVALUATION_CSV), skipinitialspace=True)
+REVALUATIONS = pd.read_csv(StringIO(REVALUATIONS_CSV), skipinitialspace=True)
 
 # flake8: noqa: E501
 EXPECTED_BALANCE_CSV = """
     date,         account, balance
     2023-12-31, 1000:9999, "{reporting_currency: 0.0, USD: 0.0, EUR: 0.0, JPY: 0.0}"
     2024-01-01, 1000:9999, "{reporting_currency: 0.0, USD: -298332.82, EUR: 120.0, JPY: 42000000.0}"
-    2024-01-01,      1000, "{reporting_currency: 800000.00, USD:   800000.00}"
-    2024-01-01,      1010, "{reporting_currency:    132.82, EUR:      120.00}"
-    2024-01-01,      1020, "{reporting_currency: 298200.00, JPY: 42000000.00}"
+    2024-01-01, 1000:1999, "{reporting_currency: 1098332.82, USD:   800000.00, EUR: 120.0, JPY: 42000000.0}"
+    2024-01-01,      1000, "{reporting_currency:  800000.00, USD:   800000.00}"
+    2024-01-01,      1010, "{reporting_currency:     132.82, EUR:      120.00}"
+    2024-01-01,      1020, "{reporting_currency:  298200.00, JPY: 42000000.00}"
+    2024-01-23,      1000, "{reporting_currency:  800000.00, USD:   800000.00}"
+    2024-01-23,      2200, "{reporting_currency:       0.00, USD:        0.00}"
+    2024-01-24,      1000, "{reporting_currency:  801200.00, USD:   801200.00}"
+    2024-01-24,      2200, "{reporting_currency:    -200.00, USD:     -200.00}"
+    2024-03-30, 1000:1999, "{reporting_currency: 1099532.82, USD:   801200.00, EUR: 120.0, JPY: 42000000.0}"
+    2024-03-31, 1000:1999, "{reporting_currency: 1078529.53, USD:   801200.00, EUR: 120.0, JPY: 42000000.0}"
+    2024-03-31,      7050, "{reporting_currency:   21003.29, USD:    21003.29}"
+    2024-03-31,      8050, "{reporting_currency:       0.00, USD:        0.00}"
 """
 EXPECTED_BALANCE = pd.read_csv(StringIO(EXPECTED_BALANCE_CSV), skipinitialspace=True)
 EXPECTED_BALANCE["balance"] = (EXPECTED_BALANCE["balance"]
@@ -146,5 +155,5 @@ class BaseTest(ABC):
     LEDGER_ENTRIES = LedgerEngine.standardize_ledger_columns(LEDGER)
     ASSETS = LedgerEngine.standardize_assets(ASSETS)
     PRICES = LedgerEngine.standardize_price_df(PRICES)
-    REVALUATION = LedgerEngine.standardize_revaluations(REVALUATION)
+    REVALUATIONS = LedgerEngine.standardize_revaluations(REVALUATIONS)
     EXPECTED_BALANCE = EXPECTED_BALANCE

--- a/pyledger/tests/test_accounts.py
+++ b/pyledger/tests/test_accounts.py
@@ -24,8 +24,9 @@ class TestAccounts(BaseTestAccounts):
         ledger._prices = ledger.standardize_prices(self.PRICES)
         for _, row in self.EXPECTED_BALANCE.iterrows():
             date = datetime.datetime.strptime(row['date'], "%Y-%m-%d").date()
+            account = row['account']
             expected = row['balance']
             actual = ledger.account_balance(date=date, account=row['account'])
             assert expected == actual, (
-                f"Account balance for {row['account']} on {date} of {actual} differs from {expected}."
+                f"Account balance for {account} on {date} of {actual} differs from {expected}."
             )

--- a/pyledger/tests/test_accounts.py
+++ b/pyledger/tests/test_accounts.py
@@ -18,10 +18,11 @@ class TestAccounts(BaseTestAccounts):
     def test_account_balance(self, ledger):
         ledger.restore(accounts=self.ACCOUNTS, settings=self.SETTINGS, tax_codes=self.TAX_CODES,
                        ledger=self.LEDGER_ENTRIES, assets=self.ASSETS)
-        # HACK: Add prices DataFrame directly to MemoryLedger.
-        #       Replace by ledger.restore(prices=self.PRICES) once accessors
-        #       and mutators for prices are implemented.
+        # HACK: Add prices and revaluations DataFrames directly to MemoryLedger.
+        #       Replace by ledger.restore(prices=self.PRICES, revaluations=self.REVALUATIONS)
+        #       once accessors and mutators for prices are implemented.
         ledger._prices = ledger.standardize_prices(self.PRICES)
+        ledger._revaluations = ledger.standardize_revaluations(self.REVALUATIONS)
         for _, row in self.EXPECTED_BALANCE.iterrows():
             date = datetime.datetime.strptime(row['date'], "%Y-%m-%d").date()
             account = row['account']

--- a/pyledger/tests/test_accounts.py
+++ b/pyledger/tests/test_accounts.py
@@ -1,5 +1,6 @@
 """Test suite for accounts operations."""
 
+import datetime
 import pytest
 from .base_accounts import BaseTestAccounts
 from pyledger import MemoryLedger
@@ -10,3 +11,21 @@ class TestAccounts(BaseTestAccounts):
     @pytest.fixture
     def ledger(self):
         return MemoryLedger()
+
+    # TODO: This test is only implemented for MemoryLedger for now.
+    # We will create an integration test 'BaseTextAccount' for all ledger
+    # classes once the restore method can handle prices and revaluations.
+    def test_account_balance(self, ledger):
+        ledger.restore(accounts=self.ACCOUNTS, settings=self.SETTINGS, tax_codes=self.TAX_CODES,
+                       ledger=self.LEDGER_ENTRIES, assets=self.ASSETS)
+        # HACK: Add prices DataFrame directly to MemoryLedger.
+        #       Replace by ledger.restore(prices=self.PRICES) once accessors
+        #       and mutators for prices are implemented.
+        ledger._prices = ledger.standardize_prices(self.PRICES)
+        for _, row in self.EXPECTED_BALANCE.iterrows():
+            date = datetime.datetime.strptime(row['date'], "%Y-%m-%d").date()
+            expected = row['balance']
+            actual = ledger.account_balance(date=date, account=row['account'])
+            assert expected == actual, (
+                f"Account balance for {row['account']} on {date} of {actual} differs from {expected}."
+            )


### PR DESCRIPTION
Add a test to ensure that account balances are correctly calculated for a complete ledger system with tax and currency revaluations.

This first version of integration test is limited in scope, but provides sufficient coverage to ensure that the upcoming refactoring of the StandaloneLedger class does not break the functionality. 

- Only tests the memory ledger class. Tests can be easily extended to other classes ones accessors and mutators for price and revaluations are implemented.
- Limited number of test cases: ATM tax codes exclusive of VAT or with a contra account are not tested. 

My goal was to quickly set a solid foundation for the upcoming refactoring step. Test coverage can be extended any time, and the test may be relocated to a different unit in a later version.