### PR TITLE
Standardize base tests

### DIFF
--- a/pyledger/tests/base_test_revaluation.py
+++ b/pyledger/tests/base_test_revaluation.py
@@ -28,7 +28,7 @@ class BaseTestRevaluations(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Modify with only id columns and one column to update
+        # Modify only a single column in a specific row
         revaluations.loc[0, "debit"] = 1005
         engine.revaluations.modify([{
             "account": revaluations.loc[0, "account"],
@@ -40,7 +40,7 @@ class BaseTestRevaluations(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Modify with a DataFrame containing all columns from the schema
+        # Modify all columns from the schema in a specific row
         revaluations.loc[3, "description"] = "Modify with all columns test"
         engine.revaluations.modify([revaluations.loc[3]])
         assert_frame_equal(
@@ -56,7 +56,7 @@ class BaseTestRevaluations(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Delete single row
+        # Delete a single row
         engine.revaluations.delete([{
             "account": revaluations['account'].iloc[0],
             "date": revaluations['date'].iloc[0],

--- a/pyledger/tests/base_test_revaluation.py
+++ b/pyledger/tests/base_test_revaluation.py
@@ -103,23 +103,28 @@ class BaseTestRevaluations(BaseTest):
         # Ensure the DataFrame passed as argument to revaluations.mirror() remains unchanged.
         assert_frame_equal(target, original_target, ignore_row_order=True)
         assert_frame_equal(
-            target, ledger.revaluations.list(),
-            ignore_row_order=True, check_like=True
+            target, ledger.revaluations.list(), ignore_row_order=True, check_like=True
         )
 
+        # Mirror with delete=False shouldn't change the data
         target = self.REVALUATIONS.query("credit not in [8050]")
+        ledger.revaluations.mirror(target, delete=False)
+        assert_frame_equal(
+            original_target, ledger.revaluations.list(), ignore_row_order=True, check_like=True
+        )
+
+        # Mirror with delete=True should change the data
         ledger.revaluations.mirror(target, delete=True)
         assert_frame_equal(
-            target, ledger.revaluations.list(),
-            ignore_row_order=True, check_like=True
+            target, ledger.revaluations.list(), ignore_row_order=True, check_like=True
         )
 
+        # Reshuffle target data randomly and modify one of the rows
         target = target.sample(frac=1).reset_index(drop=True)
         target.loc[target["account"] == "1000:2999", "description"] = "New Description"
         ledger.revaluations.mirror(target, delete=True)
         assert_frame_equal(
-            target, ledger.revaluations.list(),
-            ignore_row_order=True, check_like=True
+            target, ledger.revaluations.list(), ignore_row_order=True, check_like=True
         )
 
     def test_mirror_empty_revaluations(self, ledger):

--- a/pyledger/tests/base_test_revaluation.py
+++ b/pyledger/tests/base_test_revaluation.py
@@ -18,19 +18,11 @@ class BaseTestRevaluations(BaseTest):
     def test_revaluations_accessor_mutators(self, engine, ignore_row_order=False):
         engine.restore(settings=self.SETTINGS, accounts=self.ACCOUNTS)
 
-        # Add revaluations one by one
-        revaluations = self.REVALUATIONS.head(-3).sample(frac=1).reset_index(drop=True)
-        for revaluation in revaluations.to_dict('records'):
+        # Add revaluations one by one and with multiple rows
+        revaluations = self.REVALUATIONS.sample(frac=1).reset_index(drop=True)
+        for revaluation in revaluations.head(-3).to_dict('records'):
             engine.revaluations.add([revaluation])
-        assert_frame_equal(
-            engine.revaluations.list(), revaluations,
-            check_like=True, ignore_row_order=ignore_row_order
-        )
-
-        # Add revaluations as a DataFrame with a multiple rows
-        tail_revaluations = self.REVALUATIONS.tail(3).sample(frac=1)
-        engine.revaluations.add(tail_revaluations)
-        revaluations = pd.concat([revaluations, tail_revaluations], ignore_index=True)
+        engine.revaluations.add(revaluations.tail(3))
         assert_frame_equal(
             engine.revaluations.list(), revaluations,
             check_like=True, ignore_row_order=ignore_row_order

--- a/pyledger/tests/base_test_revaluation.py
+++ b/pyledger/tests/base_test_revaluation.py
@@ -48,9 +48,9 @@ class BaseTestRevaluations(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Modify with a multiple rows at the same time
-        revaluations.loc[revaluations.index[-2:], "description"] = "Modify multiple rows"
-        engine.revaluations.modify(revaluations.loc[revaluations.index[-2:]])
+        # Modify with a multiple rows
+        revaluations.loc[revaluations.index[[1, -1]], "description"] = "Modify multiple rows"
+        engine.revaluations.modify(revaluations.loc[revaluations.index[[1, -1]]])
         assert_frame_equal(
             engine.revaluations.list(), revaluations,
             check_like=True, ignore_row_order=ignore_row_order

--- a/pyledger/tests/base_test_revaluation.py
+++ b/pyledger/tests/base_test_revaluation.py
@@ -30,11 +30,11 @@ class BaseTestRevaluations(BaseTest):
 
         # Modify with only id columns and one column to update
         revaluations.loc[0, "debit"] = 1005
-        engine.revaluations.modify({
-            "account": [revaluations.loc[0, "account"]],
-            "date": [revaluations.loc[0, "date"]],
-            "debit": [1005]
-        })
+        engine.revaluations.modify([{
+            "account": revaluations.loc[0, "account"],
+            "date": revaluations.loc[0, "date"],
+            "debit": 1005
+        }])
         assert_frame_equal(
             engine.revaluations.list(), revaluations,
             check_like=True, ignore_row_order=ignore_row_order

--- a/pyledger/tests/base_test_revaluation.py
+++ b/pyledger/tests/base_test_revaluation.py
@@ -82,9 +82,10 @@ class BaseTestRevaluations(BaseTest):
                 "debit": 1111, "credit": 2222, "description": "Revaluation description"
             }])
 
-    def test_delete_revaluation_allow_missing(self, ledger):
-        ledger.restore(revaluations=self.REVALUATIONS, settings=self.SETTINGS)
-        with pytest.raises(ValueError, match="Some ids are not present in the data."):
+    def test_delete_revaluation_allow_missing(
+        self, ledger, error_class=ValueError, error_message="Some ids are not present in the data."
+    ):
+        with pytest.raises(error_class, match=error_message):
             ledger.revaluations.delete([{
                 "account": "1000:5000", "date": datetime.date(2023, 1, 1),
                 "debit": 1111, "credit": 2222, "description": "Revaluation description"

--- a/pyledger/tests/test_revaluations.py
+++ b/pyledger/tests/test_revaluations.py
@@ -8,5 +8,5 @@ from pyledger import MemoryLedger
 class TestRevaluations(BaseTestRevaluations):
 
     @pytest.fixture
-    def ledger(self):
+    def engine(self):
         return MemoryLedger()

--- a/pyledger/tests/test_text_ledger_revaluations.py
+++ b/pyledger/tests/test_text_ledger_revaluations.py
@@ -8,5 +8,5 @@ from pyledger import TextLedger
 class TestRevaluations(BaseTestRevaluations):
 
     @pytest.fixture
-    def ledger(self, tmp_path):
+    def engine(self, tmp_path):
         return TextLedger(tmp_path)


### PR DESCRIPTION
This PR updates the test suites to align all entity base tests with a consistent, standard approach, with the **exception of the Ledger entity base test**.

During this work, I identified an opportunity for an improved architectural approach. Introducing a factory pattern for base tests, similar to what we implemented for class entities, would enhance flexibility and maintainability in the future.
