### PR TITLE
Refactor `LedgerCSVDataFrameEntity` class `modify()` method

### DIFF
--- a/pyledger/storage_entity.py
+++ b/pyledger/storage_entity.py
@@ -664,6 +664,23 @@ class LedgerCSVDataFrameEntity(TabularLedgerEntity, CSVDataFrameEntity):
         return incoming[self._id_columns].iloc[0].to_dict()
 
     def modify(self, data: pd.DataFrame):
+        """
+        Modify existing ledger entries.
+
+        Overrides the base implementation because `LedgerDataFrameEntity.modify`
+        does not preserve the order of rows within the file.
+
+        Args:
+            data (pd.DataFrame): DataFrame containing ledger entries to modify. Must contain all
+                required columns as defined in the schema; other columns are optional.
+
+        Raises:
+            ValueError: If a combination of ID columns is not present in `data`.
+
+        Notes:
+            - Modifying only specific columns isn't supported. Collective transactions span
+            multiple rows and it is impossible to identify which row to update.
+        """
         incoming = self.standardize(pd.DataFrame(data))
         current = self.list()
 

--- a/pyledger/storage_entity.py
+++ b/pyledger/storage_entity.py
@@ -665,16 +665,20 @@ class LedgerCSVDataFrameEntity(TabularLedgerEntity, CSVDataFrameEntity):
 
     def modify(self, data: pd.DataFrame):
         incoming = self.standardize(pd.DataFrame(data))
-        for id in incoming["id"].unique():
-            current = self.list()
-            path = self._csv_path(pd.Series(id)).item()
-            df_same_file = current[self._csv_path(current["id"]) == path]
-            if id not in df_same_file["id"].values:
-                raise ValueError(f"Ledger entry with id '{id}' not present in the data.")
+        current = self.list()
 
-            df_same_file = pd.concat([
-                df_same_file[df_same_file["id"] != id], incoming.query("id == @id")
-            ])
+        missing_ids = set(incoming["id"].unique()) - set(current["id"].unique())
+        if missing_ids:
+            raise ValueError(f"Ledger entries with ids '{missing_ids}' not present in the data.")
+
+        current = current[~current["id"].isin(incoming["id"])]
+        updated = pd.concat([current, incoming], ignore_index=True)
+        paths_to_update = self._csv_path(incoming["id"]).unique()
+        for path in paths_to_update:
+            df_same_file = updated[self._csv_path(updated["id"]) == path]
+            df_same_file = df_same_file.iloc[
+                self._id_from_path(df_same_file["id"]).argsort(kind='mergesort')
+            ]
             self._store(df_same_file, self._path / path)
 
     def delete(self, id: pd.DataFrame, allow_missing: bool = False):

--- a/pyledger/text_ledger.py
+++ b/pyledger/text_ledger.py
@@ -159,7 +159,7 @@ class TextLedger(StandaloneLedger):
         df = enforce_schema(df, LEDGER_SCHEMA, sort_columns=True, keep_extra_columns=True)
 
         # Record date only on the first row of collective transactions
-        # df = df.iloc[self.ledger._id_from_path(df["id"]).argsort(kind="mergesort")]
+        df = df.iloc[self.ledger._id_from_path(df["id"]).argsort(kind="mergesort")]
         df["date"] = df["date"].where(~df.duplicated(subset="id"), None)
 
         # Apply the smallest precision

--- a/pyledger/text_ledger.py
+++ b/pyledger/text_ledger.py
@@ -159,7 +159,7 @@ class TextLedger(StandaloneLedger):
         df = enforce_schema(df, LEDGER_SCHEMA, sort_columns=True, keep_extra_columns=True)
 
         # Record date only on the first row of collective transactions
-        df = df.iloc[self.ledger._id_from_path(df["id"]).argsort(kind="mergesort")]
+        # df = df.iloc[self.ledger._id_from_path(df["id"]).argsort(kind="mergesort")]
         df["date"] = df["date"].where(~df.duplicated(subset="id"), None)
 
         # Apply the smallest precision


### PR DESCRIPTION
This PR resolves Issue #58. Please review the [latest comment on the issue](https://github.com/macxred/pyledger/issues/58#issuecomment-2477176155) for critical context before proceeding with the review.

#### Changes Implemented
1. **Enhanced Modify Logic**:
   - The modification process now leverages the unique IDs associated with ledger entries.
   - Outdated rows are deleted and replaced with updated ones in a single operation.

2. **Row Order Preservation**:
   - Entries are sorted based on the numeric portion of the ledger ID, ensuring consistent and logical order across all files.

### Note
As discussed, the `modify` method in this class requires a DataFrame adhering to the `LEDGER_SCHEMA`, including at least the required columns. This decision reflects the interdependence between updating collective transactions and specific columns. The approach can be revisited if future requirements demand more granular updates.