### PR TITLE
Standardize ledger base test

### DIFF
--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -164,7 +164,7 @@ class BaseTestLedger(BaseTest):
         assert all(remote["id"] != id), f"Ledger entry {id} was not deleted"
 
     def test_add_already_existed_raise_error(
-        self, ledger_engine, error_class=ValueError, error_message="already exists"
+        self, ledger_engine, error_class=ValueError, error_message="identifiers already exist."
     ):
         target = self.LEDGER_ENTRIES.query("id == '1'").copy()
         ledger_engine.ledger.add(target)

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -11,46 +11,46 @@ class BaseTestLedger(BaseTest):
 
     @abstractmethod
     @pytest.fixture
-    def ledger(self):
+    def pristine_engine(self):
         pass
 
     @pytest.fixture()
-    def ledger_engine(self, ledger):
-        ledger.restore(accounts=self.ACCOUNTS, tax_codes=self.TAX_CODES)
-        return ledger
+    def engine(self, pristine_engine):
+        pristine_engine.restore(accounts=self.ACCOUNTS, tax_codes=self.TAX_CODES)
+        return pristine_engine
 
-    def test_ledger_accessor_mutators(self, ledger, ignore_row_order=False):
+    def test_ledger_accessor_mutators(self, engine, ignore_row_order=False):
         # Add ledger entries one by one and with multiple rows
         expected = self.LEDGER_ENTRIES.copy()
         for id in expected.head(-7)["id"].unique():
-            ledger.ledger.add(expected.query(f"id == '{id}'"))
-        ledger.ledger.add(self.LEDGER_ENTRIES.tail(7))
+            engine.ledger.add(expected.query(f"id == '{id}'"))
+        engine.ledger.add(self.LEDGER_ENTRIES.tail(7))
         assert_frame_equal(
-            ledger.ledger.list(), expected,
+            engine.ledger.list(), expected,
             ignore_columns=["id"], ignore_row_order=ignore_row_order
         )
 
         # Modify all columns from the schema in a specific row
-        expected = ledger.ledger.list()
+        expected = engine.ledger.list()
         id = expected.iloc[0]["id"]
         expected.loc[expected["id"] == id, "description"] = "Modify with all columns"
-        ledger.ledger.modify(expected.loc[expected["id"] == id])
+        engine.ledger.modify(expected.loc[expected["id"] == id])
         assert_frame_equal(
-            ledger.ledger.list(), expected,
+            engine.ledger.list(), expected,
             check_like=True, ignore_row_order=ignore_row_order
         )
 
         # Modify with multiple rows
         ids = expected.tail(3)["id"].unique()
         expected.loc[expected["id"].isin(ids), "description"] = "Modify multiple rows"
-        ledger.ledger.modify(expected.loc[expected["id"].isin(ids)])
+        engine.ledger.modify(expected.loc[expected["id"].isin(ids)])
         assert_frame_equal(
-            ledger.ledger.list(), expected,
+            engine.ledger.list(), expected,
             check_like=True, ignore_row_order=ignore_row_order
         )
 
         # Modify single transaction with a collective
-        current = ledger.ledger.list()
+        current = engine.ledger.list()
         single_txn_id = current[~current["id"].duplicated(keep=False)].iloc[0]["id"]
         collective_txn = self.LEDGER_ENTRIES.query("id == '1'").copy()
         collective_txn.loc[:, "id"] = single_txn_id
@@ -58,14 +58,14 @@ class BaseTestLedger(BaseTest):
         rows_before = current.loc[:single_txn_index - 1]
         rows_after = current.loc[single_txn_index + 1:]
         expected = pd.concat([rows_before, collective_txn, rows_after], ignore_index=True)
-        ledger.ledger.modify(collective_txn)
+        engine.ledger.modify(collective_txn)
         assert_frame_equal(
-            ledger.ledger.list(), expected,
+            engine.ledger.list(), expected,
             check_like=True, ignore_row_order=ignore_row_order
         )
 
         # Modify collective transaction with a single
-        current = ledger.ledger.list()
+        current = engine.ledger.list()
         collective_txn_id = current[current["id"].duplicated(keep=False)].iloc[0]["id"]
         collective_txn_indices = current[current["id"] == collective_txn_id].index
         single_txn = self.LEDGER_ENTRIES.query("id == '2'").copy()
@@ -73,64 +73,64 @@ class BaseTestLedger(BaseTest):
         rows_before = current.loc[:collective_txn_indices[0] - 1]
         rows_after = current.loc[collective_txn_indices[-1] + 1:]
         expected = pd.concat([rows_before, single_txn, rows_after], ignore_index=True)
-        ledger.ledger.modify(single_txn)
+        engine.ledger.modify(single_txn)
         assert_frame_equal(
-            ledger.ledger.list(), expected,
+            engine.ledger.list(), expected,
             check_like=True, ignore_row_order=ignore_row_order
         )
 
         # Delete a single row
-        current = ledger.ledger.list()
+        current = engine.ledger.list()
         id_to_drop = current.loc[0]["id"]
-        ledger.ledger.delete([{"id": id_to_drop}])
+        engine.ledger.delete([{"id": id_to_drop}])
         ledger_entries = current[~current["id"].isin([id_to_drop])].reset_index(drop=True)
         assert_frame_equal(
-            ledger.ledger.list(), ledger_entries, ignore_columns=["id"],
+            engine.ledger.list(), ledger_entries, ignore_columns=["id"],
             check_like=True, ignore_row_order=ignore_row_order
         )
 
         # Delete multiple rows
-        current = ledger.ledger.list()
+        current = engine.ledger.list()
         ids_to_drop = current["id"].iloc[[1, -1]]
-        ledger.ledger.delete(current.iloc[[1, -1]])
+        engine.ledger.delete(current.iloc[[1, -1]])
         ledger_entries = current[~current["id"].isin(ids_to_drop)].reset_index(drop=True)
         assert_frame_equal(
-            ledger.ledger.list(), ledger_entries, ignore_columns=["id"],
+            engine.ledger.list(), ledger_entries, ignore_columns=["id"],
             check_like=True, ignore_row_order=ignore_row_order
         )
 
     def test_add_already_existed_raise_error(
-        self, ledger_engine, error_class=ValueError, error_message="identifiers already exist."
+        self, engine, error_class=ValueError, error_message="identifiers already exist."
     ):
         target = self.LEDGER_ENTRIES.query("id == '1'").copy()
-        ledger_engine.ledger.add(target)
+        engine.ledger.add(target)
         with pytest.raises(error_class, match=error_message):
-            ledger_engine.ledger.add(target)
+            engine.ledger.add(target)
 
     def test_modify_non_existed_raises_error(
-        self, ledger_engine, error_class=ValueError, error_message="not present in the data."
+        self, engine, error_class=ValueError, error_message="not present in the data."
     ):
         target = self.LEDGER_ENTRIES.query("id == '1'").copy()
         target["id"] = 999999
         with pytest.raises(error_class, match=error_message):
-            ledger_engine.ledger.modify(target)
+            engine.ledger.modify(target)
 
     def test_delete_entry_allow_missing(
-        self, ledger, error_class=ValueError, error_message="Some ids are not present in the data."
+        self, engine, error_class=ValueError, error_message="Some ids are not present in the data."
     ):
         with pytest.raises(error_class, match=error_message):
-            ledger.ledger.delete({"id": ["FAKE_ID"]}, allow_missing=False)
-        ledger.ledger.delete({"id": ["FAKE_ID"]}, allow_missing=True)
+            engine.ledger.delete({"id": ["FAKE_ID"]}, allow_missing=False)
+        engine.ledger.delete({"id": ["FAKE_ID"]}, allow_missing=True)
 
-    def test_mirror_ledger(self, ledger_engine):
-        ledger_engine.accounts.mirror(self.ACCOUNTS, delete=False)
+    def test_mirror_ledger(self, engine):
+        engine.accounts.mirror(self.ACCOUNTS, delete=False)
         # Mirror with one single and one collective transaction
         target = self.LEDGER_ENTRIES.query("id in ['1', '2']")
-        ledger_engine.ledger.mirror(target=target, delete=True)
-        expected = ledger_engine.ledger.standardize(target)
-        mirrored = ledger_engine.ledger.list()
-        assert sorted(ledger_engine.txn_to_str(mirrored).values()) == \
-               sorted(ledger_engine.txn_to_str(expected).values())
+        engine.ledger.mirror(target=target, delete=True)
+        expected = engine.ledger.standardize(target)
+        mirrored = engine.ledger.list()
+        assert sorted(engine.txn_to_str(mirrored).values()) == \
+               sorted(engine.txn_to_str(expected).values())
 
         # Mirror with duplicate transactions and delete=False
         target = pd.concat(
@@ -141,38 +141,38 @@ class BaseTestLedger(BaseTest):
                 self.LEDGER_ENTRIES.query("id == '2'").assign(id='7'),
             ]
         )
-        ledger_engine.ledger.mirror(target=target, delete=False)
-        expected = ledger_engine.ledger.standardize(target)
-        mirrored = ledger_engine.ledger.list()
+        engine.ledger.mirror(target=target, delete=False)
+        expected = engine.ledger.standardize(target)
+        mirrored = engine.ledger.list()
 
-        assert sorted(ledger_engine.txn_to_str(mirrored).values()) == \
-               sorted(ledger_engine.txn_to_str(expected).values())
+        assert sorted(engine.txn_to_str(mirrored).values()) == \
+               sorted(engine.txn_to_str(expected).values())
 
         # Mirror with complex transactions and delete=False
         target = self.LEDGER_ENTRIES.query("id in ['15', '16', '17', '18']")
-        ledger_engine.ledger.mirror(target=target, delete=False)
-        expected = ledger_engine.ledger.standardize(target)
-        expected = ledger_engine.sanitize_ledger(expected)
+        engine.ledger.mirror(target=target, delete=False)
+        expected = engine.ledger.standardize(target)
+        expected = engine.sanitize_ledger(expected)
         expected = pd.concat([mirrored, expected])
-        mirrored = ledger_engine.ledger.list()
-        assert sorted(ledger_engine.txn_to_str(mirrored).values()) == \
-               sorted(ledger_engine.txn_to_str(expected).values())
+        mirrored = engine.ledger.list()
+        assert sorted(engine.txn_to_str(mirrored).values()) == \
+               sorted(engine.txn_to_str(expected).values())
 
         # Mirror existing transactions with delete=False has no impact
         target = self.LEDGER_ENTRIES.query("id in ['1', '2']")
-        ledger_engine.ledger.mirror(target=target, delete=False)
-        mirrored = ledger_engine.ledger.list()
-        assert sorted(ledger_engine.txn_to_str(mirrored).values()) == \
-               sorted(ledger_engine.txn_to_str(expected).values())
+        engine.ledger.mirror(target=target, delete=False)
+        mirrored = engine.ledger.list()
+        assert sorted(engine.txn_to_str(mirrored).values()) == \
+               sorted(engine.txn_to_str(expected).values())
 
         # Mirror with delete=True
         target = self.LEDGER_ENTRIES.query("id in ['1', '2']")
-        ledger_engine.ledger.mirror(target=target, delete=True)
-        mirrored = ledger_engine.ledger.list()
-        expected = ledger_engine.ledger.standardize(target)
-        assert sorted(ledger_engine.txn_to_str(mirrored).values()) == \
-               sorted(ledger_engine.txn_to_str(expected).values())
+        engine.ledger.mirror(target=target, delete=True)
+        mirrored = engine.ledger.list()
+        expected = engine.ledger.standardize(target)
+        assert sorted(engine.txn_to_str(mirrored).values()) == \
+               sorted(engine.txn_to_str(expected).values())
 
         # Mirror an empty target state
-        ledger_engine.ledger.mirror(target=pd.DataFrame({}), delete=True)
-        assert ledger_engine.ledger.list().empty, "Mirroring empty DF should erase all ledgers"
+        engine.ledger.mirror(target=pd.DataFrame({}), delete=True)
+        assert engine.ledger.list().empty, "Mirroring empty DF should erase all ledgers"

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -193,6 +193,13 @@ class BaseTestLedger(BaseTest):
         with pytest.raises(error_class, match=error_message):
             ledger_engine.ledger.modify(target)
 
+    def test_delete_entry_allow_missing(
+        self, ledger, error_class=ValueError, error_message="Some ids are not present in the data."
+    ):
+        with pytest.raises(error_class, match=error_message):
+            ledger.ledger.delete({"id": ["FAKE_ID"]}, allow_missing=False)
+        ledger.ledger.delete({"id": ["FAKE_ID"]}, allow_missing=True)
+
     def test_mirror_ledger(self, ledger_engine):
         ledger_engine.accounts.mirror(self.ACCOUNTS, delete=False)
         # Mirror with one single and one collective transaction

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -30,7 +30,7 @@ class BaseTestLedger(BaseTest):
             ignore_columns=["id"], ignore_row_order=ignore_row_order
         )
 
-        # Modify all columns from the schema in a specific row
+        # Modify all columns from the schema in a ledger entry with a specific id
         expected = engine.ledger.list()
         id = expected.iloc[0]["id"]
         expected.loc[expected["id"] == id, "description"] = "Modify with all columns"
@@ -49,7 +49,7 @@ class BaseTestLedger(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Modify single transaction with a collective
+        # Replace an individual transaction by a collective transaction
         current = engine.ledger.list()
         single_txn_id = current[~current["id"].duplicated(keep=False)].iloc[0]["id"]
         collective_txn = self.LEDGER_ENTRIES.query("id == '1'").copy()
@@ -64,7 +64,7 @@ class BaseTestLedger(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Modify collective transaction with a single
+        # Replace a collective transaction by an individual transaction
         current = engine.ledger.list()
         collective_txn_id = current[current["id"].duplicated(keep=False)].iloc[0]["id"]
         collective_txn_indices = current[current["id"] == collective_txn_id].index
@@ -79,7 +79,7 @@ class BaseTestLedger(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Delete a single row
+        # Delete a single entry
         current = engine.ledger.list()
         id_to_drop = current.loc[0]["id"]
         engine.ledger.delete([{"id": id_to_drop}])
@@ -89,7 +89,7 @@ class BaseTestLedger(BaseTest):
             check_like=True, ignore_row_order=ignore_row_order
         )
 
-        # Delete multiple rows
+        # Delete multiple entries
         current = engine.ledger.list()
         ids_to_drop = current["id"].iloc[[1, -1]]
         engine.ledger.delete(current.iloc[[1, -1]])

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -22,9 +22,11 @@ class BaseTestLedger(BaseTest):
     def test_ledger_accessor_mutators(self, engine, ignore_row_order=False):
         # Add ledger entries one by one and with multiple rows
         expected = self.LEDGER_ENTRIES.copy()
-        for id in expected.head(-7)["id"].unique():
+        txn_ids = expected["id"].unique()
+        for id in txn_ids[:10]:
             engine.ledger.add(expected.query(f"id == '{id}'"))
-        engine.ledger.add(self.LEDGER_ENTRIES.tail(7))
+        remaining_ids = txn_ids[10:]  # noqa: F841
+        engine.ledger.add(expected.query("`id` in @remaining_ids"))
         assert_frame_equal(
             engine.ledger.list(), expected,
             ignore_columns=["id"], ignore_row_order=ignore_row_order

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -163,7 +163,7 @@ class BaseTestLedger(BaseTest):
         remote = ledger_engine.ledger.list()
         assert all(remote["id"] != id), f"Ledger entry {id} was not deleted"
 
-    def add_already_existed_raise_error(
+    def test_add_already_existed_raise_error(
         self, ledger_engine, error_class=ValueError, error_message="already exists"
     ):
         target = self.LEDGER_ENTRIES.query("id == '1'").copy()
@@ -171,7 +171,7 @@ class BaseTestLedger(BaseTest):
         with pytest.raises(error_class, match=error_message):
             ledger_engine.ledger.add(target)
 
-    def add_with_ambiguous_id_raises_error(
+    def test_add_with_ambiguous_id_raises_error(
         self, ledger_engine, error_class=ValueError, error_message="Id needs to be unique"
     ):
         target = self.LEDGER_ENTRIES.query("id in ['1', '2']").copy()
@@ -186,7 +186,7 @@ class BaseTestLedger(BaseTest):
         with pytest.raises(error_class, match=error_message):
             ledger_engine.ledger.modify(target)
 
-    def add_modify_with_ambiguous_id_raises_error(
+    def test_modify_with_ambiguous_id_raises_error(
         self, ledger_engine, error_class=ValueError, error_message="Id needs to be unique"
     ):
         target = self.LEDGER_ENTRIES.query("id in [1, 2]").copy()

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -171,25 +171,11 @@ class BaseTestLedger(BaseTest):
         with pytest.raises(error_class, match=error_message):
             ledger_engine.ledger.add(target)
 
-    def test_add_with_ambiguous_id_raises_error(
-        self, ledger_engine, error_class=ValueError, error_message="Id needs to be unique"
-    ):
-        target = self.LEDGER_ENTRIES.query("id in ['1', '2']").copy()
-        with pytest.raises(error_class, match=error_message):
-            ledger_engine.ledger.add(target)
-
     def test_modify_non_existed_raises_error(
         self, ledger_engine, error_class=ValueError, error_message="not present in the data."
     ):
         target = self.LEDGER_ENTRIES.query("id == '1'").copy()
         target["id"] = 999999
-        with pytest.raises(error_class, match=error_message):
-            ledger_engine.ledger.modify(target)
-
-    def test_modify_with_ambiguous_id_raises_error(
-        self, ledger_engine, error_class=ValueError, error_message="Id needs to be unique"
-    ):
-        target = self.LEDGER_ENTRIES.query("id in [1, 2]").copy()
         with pytest.raises(error_class, match=error_message):
             ledger_engine.ledger.modify(target)
 

--- a/pyledger/tests/test_ledger.py
+++ b/pyledger/tests/test_ledger.py
@@ -10,3 +10,6 @@ class TestLedger(BaseTestLedger):
     @pytest.fixture
     def ledger(self):
         return MemoryLedger()
+
+    def test_ledger_accessor_mutators(self, ledger):
+        super().test_ledger_accessor_mutators(ledger, ignore_row_order=True)

--- a/pyledger/tests/test_ledger.py
+++ b/pyledger/tests/test_ledger.py
@@ -8,8 +8,8 @@ from pyledger import MemoryLedger
 class TestLedger(BaseTestLedger):
 
     @pytest.fixture
-    def ledger(self):
+    def pristine_engine(self):
         return MemoryLedger()
 
-    def test_ledger_accessor_mutators(self, ledger):
-        super().test_ledger_accessor_mutators(ledger, ignore_row_order=True)
+    def test_ledger_accessor_mutators(self, pristine_engine):
+        super().test_ledger_accessor_mutators(pristine_engine, ignore_row_order=True)

--- a/pyledger/tests/test_text_ledger_ledger.py
+++ b/pyledger/tests/test_text_ledger_ledger.py
@@ -13,6 +13,10 @@ class TestLedger(BaseTestLedger):
     def ledger(self, tmp_path):
         return TextLedger(tmp_path)
 
+    @pytest.mark.skip(reason="TextLedger ignores incoming IDs when adding entries.")
+    def test_add_already_existed_raise_error(self):
+        pass
+
     def test_write_ledger_directory(self, ledger):
         # Define ledger entries with different nesting level
         file_1 = self.LEDGER_ENTRIES.copy()

--- a/pyledger/tests/test_text_ledger_ledger.py
+++ b/pyledger/tests/test_text_ledger_ledger.py
@@ -56,26 +56,3 @@ class TestLedger(BaseTestLedger):
         """Ledger() is expected to return an empty data frame if the ledger folder is missing."""
         expected_ledger = ledger.ledger.standardize(None)
         assert_frame_equal(ledger.ledger.list(), expected_ledger)
-
-    def test_ledger_mutators_does_not_change_order(self, ledger):
-        """Test to ensure that mutator functions make minimal invasive changes to ledger files,
-        preserving the original row order so that Git diffs show only the intended modifications.
-        """
-        for id in self.LEDGER_ENTRIES['id'].unique():
-            ledger.ledger.add(self.LEDGER_ENTRIES.query(f"id == '{id}'"))
-        expected = ledger.ledger.standardize(self.LEDGER_ENTRIES)
-        expected["id"] = "default.csv:" + expected["id"]
-        assert_frame_equal(ledger.ledger.list(), expected)
-
-        expected.loc[expected["id"] == "default.csv:4", "amount"] = 8888888888
-        df = expected.query("id == 'default.csv:4'")
-        ledger.ledger.modify(df)
-        expected.loc[expected["id"] == "default.csv:9", "amount"] = 7777777777
-        df = expected.query("id == 'default.csv:9'")
-        ledger.ledger.modify(df)
-        assert_frame_equal(ledger.ledger.list(), expected)
-
-        to_delete = ['default.csv:3', 'default.csv:10']
-        expected = expected.query(f"id not in {to_delete}")
-        ledger.ledger.delete({"id": to_delete})
-        assert_frame_equal(ledger.ledger.list(), expected, ignore_columns=["id"], ignore_index=True)

--- a/pyledger/tests/test_text_ledger_ledger.py
+++ b/pyledger/tests/test_text_ledger_ledger.py
@@ -10,14 +10,14 @@ from .base_test_ledger import BaseTestLedger
 class TestLedger(BaseTestLedger):
 
     @pytest.fixture
-    def ledger(self, tmp_path):
+    def pristine_engine(self, tmp_path):
         return TextLedger(tmp_path)
 
     @pytest.mark.skip(reason="TextLedger ignores incoming IDs when adding entries.")
     def test_add_already_existed_raise_error(self):
         pass
 
-    def test_write_ledger_directory(self, ledger):
+    def test_write_ledger_directory(self, pristine_engine):
         # Define ledger entries with different nesting level
         file_1 = self.LEDGER_ENTRIES.copy()
         file_1["id"] = "level1/level2/file1.csv:" + file_1["id"]
@@ -28,31 +28,31 @@ class TestLedger(BaseTestLedger):
 
         # Populate ledger directory and check that ledger() returns original data
         expected = pd.concat([file_1, file_2], ignore_index=True)
-        ledger.ledger.write_directory(expected)
-        expected = ledger.ledger.standardize(expected)
-        assert_frame_equal(expected, ledger.ledger.list(), ignore_row_order=True)
+        pristine_engine.ledger.write_directory(expected)
+        expected = pristine_engine.ledger.standardize(expected)
+        assert_frame_equal(expected, pristine_engine.ledger.list(), ignore_row_order=True)
 
         # Populate ledger directory with a subset and check that superfluous file is deleted
-        ledger.ledger.write_directory(file_1)
-        expected = ledger.ledger.standardize(file_1)
-        assert_frame_equal(expected, ledger.ledger.list())
-        ledger_root = ledger.root_path / "ledger"
+        pristine_engine.ledger.write_directory(file_1)
+        expected = pristine_engine.ledger.standardize(file_1)
+        assert_frame_equal(expected, pristine_engine.ledger.list())
+        ledger_root = pristine_engine.root_path / "ledger"
         assert not (ledger_root / "file2.csv").exists(), "'file2.csv' was not deleted."
 
         # Clear ledger directory and ensure all ledger files are deleted
-        ledger.ledger.write_directory(ledger.ledger.standardize(None))
+        pristine_engine.ledger.write_directory(pristine_engine.ledger.standardize(None))
         assert not any(ledger_root.rglob("*.csv")), "Some files were not deleted."
-        assert ledger.ledger.list().empty, "Ledger is not empty."
+        assert pristine_engine.ledger.list().empty, "Ledger is not empty."
 
-    def test_write_empty_ledger_directory(self, ledger):
-        ledger.ledger.write_directory(ledger.ledger.standardize(None))
-        ledger_path = ledger.root_path / "ledger"
+    def test_write_empty_ledger_directory(self, pristine_engine):
+        pristine_engine.ledger.write_directory(pristine_engine.ledger.standardize(None))
+        ledger_path = pristine_engine.root_path / "ledger"
         assert not ledger_path.exists() or not any(ledger_path.iterdir()), (
             "The ledger directory should be empty or non-existent"
         )
-        assert ledger.ledger.list().empty, "Reading ledger files should return empty df"
+        assert pristine_engine.ledger.list().empty, "Reading ledger files should return empty df"
 
-    def test_ledger_without_ledger_folder(self, ledger):
+    def test_ledger_without_ledger_folder(self, pristine_engine):
         """Ledger() is expected to return an empty data frame if the ledger folder is missing."""
-        expected_ledger = ledger.ledger.standardize(None)
-        assert_frame_equal(ledger.ledger.list(), expected_ledger)
+        expected_ledger = pristine_engine.ledger.standardize(None)
+        assert_frame_equal(pristine_engine.ledger.list(), expected_ledger)


### PR DESCRIPTION
This PR aligns and standardizes the ledger base test with the rest of the base tests, ensuring consistency across the test framework.

Key changes:
- **Dropped redundant tests:** Removed some tests (e.g., accessor/mutators without tax codes) as they appeared unnecessary. Please let me know if you feel we are missing essential test cases.
- **Streamlined transaction type logic:** Incorporated logic for converting transaction types (single/collective) directly within the accessor/mutators test. Suggestions for improving this implementation are welcome!

Feedback is appreciated, especially if there are concerns about missing test coverage or better ways to handle transaction type logic.