### PR TITLE
Coherent naming in base tests

### DIFF
--- a/pyledger/tests/test_ledger.py
+++ b/pyledger/tests/test_ledger.py
@@ -8,8 +8,8 @@ from pyledger import MemoryLedger
 class TestLedger(BaseTestLedger):
 
     @pytest.fixture
-    def pristine_engine(self):
+    def engine(self):
         return MemoryLedger()
 
-    def test_ledger_accessor_mutators(self, pristine_engine):
-        super().test_ledger_accessor_mutators(pristine_engine, ignore_row_order=True)
+    def test_ledger_accessor_mutators(self, engine):
+        super().test_ledger_accessor_mutators(engine, ignore_row_order=True)

--- a/pyledger/tests/test_text_ledger_ledger.py
+++ b/pyledger/tests/test_text_ledger_ledger.py
@@ -10,14 +10,14 @@ from .base_test_ledger import BaseTestLedger
 class TestLedger(BaseTestLedger):
 
     @pytest.fixture
-    def pristine_engine(self, tmp_path):
+    def engine(self, tmp_path):
         return TextLedger(tmp_path)
 
     @pytest.mark.skip(reason="TextLedger ignores incoming IDs when adding entries.")
     def test_add_already_existed_raise_error(self):
         pass
 
-    def test_write_ledger_directory(self, pristine_engine):
+    def test_write_ledger_directory(self, engine):
         # Define ledger entries with different nesting level
         file_1 = self.LEDGER_ENTRIES.copy()
         file_1["id"] = "level1/level2/file1.csv:" + file_1["id"]
@@ -28,31 +28,31 @@ class TestLedger(BaseTestLedger):
 
         # Populate ledger directory and check that ledger() returns original data
         expected = pd.concat([file_1, file_2], ignore_index=True)
-        pristine_engine.ledger.write_directory(expected)
-        expected = pristine_engine.ledger.standardize(expected)
-        assert_frame_equal(expected, pristine_engine.ledger.list(), ignore_row_order=True)
+        engine.ledger.write_directory(expected)
+        expected = engine.ledger.standardize(expected)
+        assert_frame_equal(expected, engine.ledger.list(), ignore_row_order=True)
 
         # Populate ledger directory with a subset and check that superfluous file is deleted
-        pristine_engine.ledger.write_directory(file_1)
-        expected = pristine_engine.ledger.standardize(file_1)
-        assert_frame_equal(expected, pristine_engine.ledger.list())
-        ledger_root = pristine_engine.root_path / "ledger"
+        engine.ledger.write_directory(file_1)
+        expected = engine.ledger.standardize(file_1)
+        assert_frame_equal(expected, engine.ledger.list())
+        ledger_root = engine.root_path / "ledger"
         assert not (ledger_root / "file2.csv").exists(), "'file2.csv' was not deleted."
 
         # Clear ledger directory and ensure all ledger files are deleted
-        pristine_engine.ledger.write_directory(pristine_engine.ledger.standardize(None))
+        engine.ledger.write_directory(engine.ledger.standardize(None))
         assert not any(ledger_root.rglob("*.csv")), "Some files were not deleted."
-        assert pristine_engine.ledger.list().empty, "Ledger is not empty."
+        assert engine.ledger.list().empty, "Ledger is not empty."
 
-    def test_write_empty_ledger_directory(self, pristine_engine):
-        pristine_engine.ledger.write_directory(pristine_engine.ledger.standardize(None))
-        ledger_path = pristine_engine.root_path / "ledger"
+    def test_write_empty_ledger_directory(self, engine):
+        engine.ledger.write_directory(engine.ledger.standardize(None))
+        ledger_path = engine.root_path / "ledger"
         assert not ledger_path.exists() or not any(ledger_path.iterdir()), (
             "The ledger directory should be empty or non-existent"
         )
-        assert pristine_engine.ledger.list().empty, "Reading ledger files should return empty df"
+        assert engine.ledger.list().empty, "Reading ledger files should return empty df"
 
-    def test_ledger_without_ledger_folder(self, pristine_engine):
+    def test_ledger_without_ledger_folder(self, engine):
         """Ledger() is expected to return an empty data frame if the ledger folder is missing."""
-        expected_ledger = pristine_engine.ledger.standardize(None)
-        assert_frame_equal(pristine_engine.ledger.list(), expected_ledger)
+        expected_ledger = engine.ledger.standardize(None)
+        assert_frame_equal(engine.ledger.list(), expected_ledger)


### PR DESCRIPTION
This PR follows up on #62 and align names in ledger base test with other base tests.

Changes:
1. Use `engine` rather than `pristine_engine` to name the fixture that instantiates the accounting engine, as in other base tests.
2. Rename fixture that represents a pre-populated accounting engine for testing to `restore_engine`.
3. Clear any existing ledger entries in `restore_engine`. This will be helpful when testing connections to external systems such as CashCtrl, that will not start from a pristine state.