### PR TITLE
Comparsion NA values fix

### DIFF
--- a/pyledger/storage_entity.py
+++ b/pyledger/storage_entity.py
@@ -171,7 +171,10 @@ class AccountingEntity(ABC):
         incoming_cols = current_cols.str.replace("_current$", "", regex=True)
         both_rows = merged[merged['_merge'] == 'both']
         current_rows = both_rows[current_cols].rename(columns=lambda x: x.replace("_current", ""))
-        diff = current_rows.ne(both_rows[incoming_cols]).any(axis=1)
+        diff_values = current_rows.ne(both_rows[incoming_cols])
+        # Comparing of NA values isn't possible using .ne(), need to compare NA values separately.
+        diff_nans = current_rows.isna() != both_rows[incoming_cols].isna()
+        diff = (diff_values | diff_nans).any(axis=1)
         to_update = both_rows.loc[diff, incoming.columns]
         if len(to_update):
             self.modify(to_update)

--- a/pyledger/tests/base_test_accounts.py
+++ b/pyledger/tests/base_test_accounts.py
@@ -137,7 +137,8 @@ class BaseTestAccounts(BaseTest):
 
         # Reshuffle target data randomly and modify one of the rows
         target = target.sample(frac=1).reset_index(drop=True)
-        target.loc[target["account"] == "2000", "description"] = "Test mirror description"
+        target.loc[target["account"] == 2000, "description"] = "Test mirror description"
+        target.loc[target["account"] == 5000, "description"] = pd.NA
         engine.accounts.mirror(target, delete=True)
         assert_frame_equal(target, engine.accounts.list(), ignore_row_order=True, check_like=True)
 


### PR DESCRIPTION
Comparisons involving `pd.NA` in Pandas DataFrames result in `pd.NA`, not boolean values, which causes methods like `.ne()` and `.any()` to miss differences involving missing values.

This update addresses the issue by separately comparing the missing value statuses using `.isna()` and combining the results with the value comparisons. This ensures that all differences—including those where values change to or from `pd.NA`—are accurately detected.

Do we need to test that case in all entities base tests?