### PR TITLE
Base tests for accounts and tax codes

### DIFF
--- a/pyledger/tests/base_test_accounts.py
+++ b/pyledger/tests/base_test_accounts.py
@@ -138,7 +138,7 @@ class BaseTestAccounts(BaseTest):
         # Reshuffle target data randomly and modify one of the rows
         target = target.sample(frac=1).reset_index(drop=True)
         target.loc[target["account"] == 2000, "description"] = "Test mirror description"
-        target.loc[target["account"] == 5000, "description"] = pd.NA
+        target.loc[target["account"] == 5000, "tax_code"] = pd.NA
         engine.accounts.mirror(target, delete=True)
         assert_frame_equal(target, engine.accounts.list(), ignore_row_order=True, check_like=True)
 

--- a/pyledger/tests/base_test_tax_codes.py
+++ b/pyledger/tests/base_test_tax_codes.py
@@ -137,7 +137,11 @@ class BaseTestTaxCodes(BaseTest):
 
     def test_mirror_empty_tax_codes(self, restored_engine):
         engine = restored_engine
-        engine.restore(tax_codes=self.TAX_CODES, accounts=self.ACCOUNTS, settings=self.SETTINGS)
+        tax_accounts = pd.concat([
+            self.TAX_CODES["account"], self.TAX_CODES["contra"]
+        ]).dropna().unique()
+        tax_accounts = self.ACCOUNTS.query("`account` in @tax_accounts")
+        engine.restore(tax_codes=self.TAX_CODES, accounts=tax_accounts, settings=self.SETTINGS)
         assert not engine.tax_codes.list().empty, "Tax codes were not populated"
         engine.tax_codes.mirror(engine.tax_codes.standardize(None), delete=True)
         assert engine.tax_codes.list().empty, "Mirroring empty df should erase all tax codes"


### PR DESCRIPTION
This PR contains two changes:

- Restoring tax codes requires accounts in the `test_mirror_empty_tax_codes`
- Set `tax_code` to NA instead of `description`