### PR TITLE
Align ledger base test for `cashctrl`

### DIFF
--- a/pyledger/__init__.py
+++ b/pyledger/__init__.py
@@ -37,4 +37,4 @@ from .tests import (
     BaseTestPriceHistory,
     BaseTestRevaluations,
 )
-from .storage_entity import AccountingEntity, CSVAccountingEntity
+from .storage_entity import AccountingEntity, CSVAccountingEntity, LedgerEntity

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -50,12 +50,12 @@ LEDGER_CSV = """
      5, 2024-05-05,    1000,   5000,      USD,     -555.55,              ,   IN_STD, Purchase with tax, 2024/payables/2024-05-05.pdf
      6, 2024-05-06,    1000,   5000,      USD,     -666.66,              ,   IN_RED, Purchase at reduced tax, 2024/payables/2024-05-06.pdf
      7, 2024-05-07,    1000,   5000,      USD,     -777.77,              ,   EXEMPT, Tax-Exempt purchase, 2024/payables/2024-05-07.pdf
-     8, 2024-05-08,    1000,       ,      USD,     -888.88,              ,         , Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
+     8, 2024-05-08,    1000,       ,      USD,     -999.99,              ,         , Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
      8,           ,        ,   5000,      USD,     -555.55,              ,   IN_STD, Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
      8,           ,        ,   5000,      USD,     -444.44,              ,   EXEMPT, Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
-     9, 2024-07-01,    1010,       ,      EUR,     1500.00,              ,         , Sale at mixed VAT rate, /invoices/invoice_002.pdf
-     9,           ,    4000,       ,      EUR,     1000.00,              ,  OUT_STD, Sale at mixed VAT rate, /invoices/invoice_002.pdf
-     9,           ,        ,   4000,      EUR,      500.00,              ,  OUT_RED, Sale at mixed VAT rate, /invoices/invoice_002.pdf
+     9, 2024-07-01,    1010,       ,      EUR,     1500.00,       1612.25,         , Sale at mixed VAT rate, /invoices/invoice_002.pdf
+     9,           ,    4000,       ,      EUR,     1000.00,       1074.83,  OUT_STD, Sale at mixed VAT rate, /invoices/invoice_002.pdf
+     9,           ,        ,   4000,      EUR,      500.00,        537.42,  OUT_RED, Sale at mixed VAT rate, /invoices/invoice_002.pdf
     10, 2024-07-04,    1020,   1000,      JPY, 12345678.00,      76386.36,         , Convert JPY to EUR, 2024/transfers/2024-07-05_JPY-EUR.pdf
     10,           ,    1010,   1000,      EUR,    70791.78,      76386.36,         , Convert JPY to EUR, 2024/transfers/2024-07-05_JPY-EUR.pdf
     11, 2024-08-06,    1000,   2000,      USD,      500.00,              ,         , Payment from customer, 2024/banking/USD_2024-Q2.pdf
@@ -69,16 +69,16 @@ LEDGER_CSV = """
     16,           ,    1010,       ,      EUR,       20.00,         20.50,         , Collective transaction - leg with credit account,
     16,           ,        ,   1015,      EUR,       20.00,         20.50,         , Collective transaction - leg with debit account,
     17, 2024-09-09,    1010,   7050,      EUR,        0.00,         -5.55,         , Manual Foreign currency adjustment
-    18, 2024-09-10,    1020,       ,      JPY,        0.00,             0,         , Manual Foreign currency adjustment
+    18, 2024-09-10,    1020,       ,      JPY,        0.00,          5.55,         , Manual Foreign currency adjustment
     18,           ,        ,   8050,      USD,        5.55,              ,         , Manual Foreign currency adjustment
     19, 2024-12-01,    1000,   3000,      EUR, 10000000.00,              ,         , Capital Increase,
     20, 2024-12-02,    1010,   2010,      EUR, 90000000.00,   91111111.10,         , Value 90 Mio USD @1.0123456789 (10 decimal places),
     21, 2024-12-03,    2010,   1010,      EUR, 90000000.00,   91111111.10,         , Revert previous entry,
-    22, 2024-12-04,        ,   1000,      USD,  9500000.00,              ,         , Convert 9.5 Mio USD to EUR @1.050409356 (9 decimal places),
-    23, 2024-12-04,    1010,       ,      EUR,  9978888.88,    9500000.00,         , Convert 9.5 Mio USD to EUR @1.050409356 (9 decimal places),
-    24, 2024-12-05,        ,   1000,      USD,   200000.00,              ,         , Convert USD to EUR and JPY,
-    24,           ,    1010,       ,      EUR,    97750.00,     100000.00,         , Convert USD to EUR and JPY,
-    24,           ,    1020,       ,      CHF, 14285714.29,     100000.00,         , Convert USD to EUR and JPY,
+    22, 2024-12-04,        ,   1000,      USD,  9500000.00,              ,         , Convert 9.5 Mio USD to EUR @1.050409354 (9 decimal places),
+    22, 2024-12-04,    1010,       ,      EUR,  9978888.87,    9500000.00,         , Convert 9.5 Mio USD to EUR @1.050409354 (9 decimal places),
+    23, 2024-12-05,        ,   1000,      USD,   200000.00,              ,         , Convert USD to EUR and CHF,
+    23,           ,    1010,       ,      EUR,    97750.00,     100000.00,         , Convert USD to EUR and CHF,
+    23,           ,    1020,       ,      CHF, 14285714.29,     100000.00,         , Convert USD to EUR and CHF,
 """
 LEDGER = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 # flake8: enable

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -53,9 +53,9 @@ LEDGER_CSV = """
      8, 2024-05-08,    1000,       ,      USD,     -999.99,              ,         , Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
      8,           ,        ,   5000,      USD,     -555.55,              ,   IN_STD, Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
      8,           ,        ,   5000,      USD,     -444.44,              ,   EXEMPT, Purchase with mixed tax rates, 2024/payables/2024-05-08.pdf
-     9, 2024-07-01,    1010,       ,      EUR,     1500.00,       1612.25,         , Sale at mixed VAT rate, /invoices/invoice_002.pdf
-     9,           ,    4000,       ,      EUR,     1000.00,       1074.83,  OUT_STD, Sale at mixed VAT rate, /invoices/invoice_002.pdf
-     9,           ,        ,   4000,      EUR,      500.00,        537.42,  OUT_RED, Sale at mixed VAT rate, /invoices/invoice_002.pdf
+     9, 2024-07-01,    1010,       ,      EUR,     1500.00,              ,         , Sale at mixed VAT rate, /invoices/invoice_002.pdf
+     9,           ,    4000,       ,      EUR,     1000.00,              ,  OUT_STD, Sale at mixed VAT rate, /invoices/invoice_002.pdf
+     9,           ,        ,   4000,      EUR,      500.00,              ,  OUT_RED, Sale at mixed VAT rate, /invoices/invoice_002.pdf
     10, 2024-07-04,    1020,   1000,      JPY, 12345678.00,      76386.36,         , Convert JPY to EUR, 2024/transfers/2024-07-05_JPY-EUR.pdf
     10,           ,    1010,   1000,      EUR,    70791.78,      76386.36,         , Convert JPY to EUR, 2024/transfers/2024-07-05_JPY-EUR.pdf
     11, 2024-08-06,    1000,   2000,      USD,      500.00,              ,         , Payment from customer, 2024/banking/USD_2024-Q2.pdf
@@ -74,8 +74,8 @@ LEDGER_CSV = """
     19, 2024-12-01,    1000,   3000,      EUR, 10000000.00,              ,         , Capital Increase,
     20, 2024-12-02,    1010,   2010,      EUR, 90000000.00,   91111111.10,         , Value 90 Mio USD @1.0123456789 (10 decimal places),
     21, 2024-12-03,    2010,   1010,      EUR, 90000000.00,   91111111.10,         , Revert previous entry,
-    22, 2024-12-04,        ,   1000,      USD,  9500000.00,              ,         , Convert 9.5 Mio USD to EUR @1.050409354 (9 decimal places),
-    22, 2024-12-04,    1010,       ,      EUR,  9978888.87,    9500000.00,         , Convert 9.5 Mio USD to EUR @1.050409354 (9 decimal places),
+    22, 2024-12-04,        ,   1000,      USD,  9500000.00,              ,         , Convert 9.5 Mio USD at EUR @1.050409356 (9 decimal places),
+    22, 2024-12-04,    1010,       ,      EUR,  9978888.88,    9500000.00,         , Convert 9.5 Mio USD at EUR @1.050409356 (9 decimal places),
     23, 2024-12-05,        ,   1000,      USD,   200000.00,              ,         , Convert USD to EUR and CHF,
     23,           ,    1010,       ,      EUR,    97750.00,     100000.00,         , Convert USD to EUR and CHF,
     23,           ,    1020,       ,      CHF, 14285714.29,     100000.00,         , Convert USD to EUR and CHF,

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -65,7 +65,7 @@ class BaseTestLedger(BaseTest):
         # Replace an individual transaction by a collective transaction
         current = engine.ledger.list()
         single_txn_id = current[~current["id"].duplicated(keep=False)].iloc[0]["id"]
-        collective_txn = self.LEDGER_ENTRIES.query("id == '1'").copy()
+        collective_txn = self.LEDGER_ENTRIES.query("id == '8'").copy()
         collective_txn.loc[:, "id"] = single_txn_id
         single_txn_index = current[current["id"] == single_txn_id].index[0]
         rows_before = current.loc[:single_txn_index - 1]
@@ -124,7 +124,7 @@ class BaseTestLedger(BaseTest):
     def test_modify_non_existed_raises_error(
         self, restored_engine, error_class=ValueError, error_message="not present in the data."
     ):
-        target = self.LEDGER_ENTRIES.query("id == '1'").copy()
+        target = self.LEDGER_ENTRIES.query("id == '2'").copy()
         target["id"] = 999999
         with pytest.raises(error_class, match=error_message):
             restored_engine.ledger.modify(target)
@@ -139,10 +139,9 @@ class BaseTestLedger(BaseTest):
 
     def test_mirror_ledger(self, restored_engine):
         engine = restored_engine
-        engine.accounts.mirror(self.ACCOUNTS, delete=False)
 
         # Mirror with one single and one collective transaction
-        target = self.LEDGER_ENTRIES.query("id in ['1', '2']")
+        target = self.LEDGER_ENTRIES.query("id in ['8', '2']")
         engine.ledger.mirror(target=target, delete=True)
         expected = engine.ledger.standardize(target)
         mirrored = engine.ledger.list()
@@ -152,8 +151,8 @@ class BaseTestLedger(BaseTest):
         # Mirror with duplicate transactions and delete=False
         target = pd.concat(
             [
-                self.LEDGER_ENTRIES.query("id == '1'").assign(id='4'),
-                self.LEDGER_ENTRIES.query("id == '1'").assign(id='5'),
+                self.LEDGER_ENTRIES.query("id == '8'").assign(id='4'),
+                self.LEDGER_ENTRIES.query("id == '8'").assign(id='5'),
                 self.LEDGER_ENTRIES.query("id == '2'").assign(id='6'),
                 self.LEDGER_ENTRIES.query("id == '2'").assign(id='7'),
             ]
@@ -166,7 +165,7 @@ class BaseTestLedger(BaseTest):
                sorted(engine.txn_to_str(expected).values())
 
         # Mirror with complex transactions and delete=False
-        target = self.LEDGER_ENTRIES.query("id in ['15', '16', '17', '18']")
+        target = self.LEDGER_ENTRIES.query("id in ['15', '16', '17', '22']")
         engine.ledger.mirror(target=target, delete=False)
         expected = engine.ledger.standardize(target)
         expected = engine.sanitize_ledger(expected)
@@ -176,14 +175,14 @@ class BaseTestLedger(BaseTest):
                sorted(engine.txn_to_str(expected).values())
 
         # Mirror existing transactions with delete=False has no impact
-        target = self.LEDGER_ENTRIES.query("id in ['1', '2']")
+        target = self.LEDGER_ENTRIES.query("id in ['8', '2']")
         engine.ledger.mirror(target=target, delete=False)
         mirrored = engine.ledger.list()
         assert sorted(engine.txn_to_str(mirrored).values()) == \
                sorted(engine.txn_to_str(expected).values())
 
         # Mirror with delete=True
-        target = self.LEDGER_ENTRIES.query("id in ['1', '2']")
+        target = self.LEDGER_ENTRIES.query("id in ['8', '2']")
         engine.ledger.mirror(target=target, delete=True)
         mirrored = engine.ledger.list()
         expected = engine.ledger.standardize(target)

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -18,7 +18,11 @@ class BaseTestLedger(BaseTest):
     def restored_engine(self, engine):
         """Accounting engine populated with accounts and tax codes,
         clear of any ledger entries."""
-        engine.restore(accounts=self.ACCOUNTS, tax_codes=self.TAX_CODES, ledger=[])
+        accounts = engine.accounts.list()
+        accounts = pd.concat([accounts, self.ACCOUNTS])
+        engine.restore(
+            accounts=accounts, tax_codes=self.TAX_CODES, ledger=[], settings=self.SETTINGS
+        )
         return engine
 
     def test_ledger_accessor_mutators(self, restored_engine, ignore_row_order=False):

--- a/pyledger/tests/base_test_ledger.py
+++ b/pyledger/tests/base_test_ledger.py
@@ -19,7 +19,7 @@ class BaseTestLedger(BaseTest):
         """Accounting engine populated with accounts and tax codes,
         clear of any ledger entries."""
         accounts = engine.accounts.list()
-        accounts = pd.concat([accounts, self.ACCOUNTS])
+        accounts = pd.concat([accounts, self.ACCOUNTS]).drop_duplicates(["account"])
         engine.restore(
             accounts=accounts, tax_codes=self.TAX_CODES, ledger=[], settings=self.SETTINGS
         )


### PR DESCRIPTION
This PR goal is to align the base test for the `Ledger` entity to make them work in `cashctrl`.

Looking Commit by commit will be beneficial.

Shout if you disagree with changes or if I broke some logic.