### PR TITLE
Further Clarify Naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ import datetime
 from pyledger import TestLedger
 
 # Instantiate a ledger engine pre-populated with hard-coded data
-ledger = TestLedger()
+engine = TestLedger()
 
 # Get accounts
-ledger.accounts.list()
+engine.accounts.list()
 ##         currency tax_code                                        description
 ## account
 ## 1000         CHF      NaN                                       Cash on hand
@@ -99,14 +99,14 @@ ledger.accounts.list()
 ## [..snip..]
 
 # Post transactions to the general ledger
-ledger.journal.add({
+engine.journal.add({
     'date': datetime.date.today(),
     'account': 1020,
     'contra': 6000,
     'currency': 'CHF',
     "description": "First Test Transaction",
     'amount': -100})
-ledger.journal.add({
+engine.journal.add({
     'date': datetime.date.today(),
     'account': 1020,
     'contra': 4000,
@@ -115,11 +115,11 @@ ledger.journal.add({
     'amount': 200})
 
 # Retrieve account balance
-ledger.account_balance(1020)
+engine.account_balance(1020)
 ## {'reporting_currency': 100.0, 'CHF': 100.0}
 
 # Retrieve an account's transaction history
-ledger.account_history(1020)
+engine.account_history(1020)
 ##   id        date  account  contra  currency  amount  balance  report_amount  report_balance  tax_code              description  document
 ## 0  1  2024-04-12     1020    6000       CHF  -100.0   -100.0         -100.0          -100.0      <NA>   First Test Transaction      <NA>
 ## 1  2  2024-04-12     1020    4000       CHF   200.0    100.0          200.0           100.0      <NA>  Second Test Transaction      <NA>

--- a/docs/TextLedger.md
+++ b/docs/TextLedger.md
@@ -79,7 +79,7 @@ JOURNAL_CSV = """
     2023-01-30,    1000,   4000,      USD,  2400.00,  OUT_STD, Sale of Goods
     2023-02-01,    1000,   7000,      USD,  -800.00,         , Rent Expense
 """
-JOURNAL_ENTRIES = pd.read_csv(StringIO(JOURNAL_CSV), skipinitialspace=True)
+JOURNAL = pd.read_csv(StringIO(JOURNAL_CSV), skipinitialspace=True)
 
 CONFIGURATION = {"reporting_currency": "USD"}
 
@@ -89,7 +89,7 @@ engine.restore(
     configuration=CONFIGURATION,
     tax_codes=TAX_CODES,
     accounts=ACCOUNT_CHART,
-    journal=JOURNAL_ENTRIES)
+    journal=JOURNAL)
 ```
 
 ### 2. Managing Journal Entries

--- a/pyledger/tests/base_test.py
+++ b/pyledger/tests/base_test.py
@@ -187,7 +187,7 @@ class BaseTest(ABC):
     ASSETS = engine.assets.standardize(ASSETS)
     ACCOUNTS = engine.accounts.standardize(ACCOUNTS)
     PRICES = engine.price_history.standardize(PRICES)
-    JOURNAL_ENTRIES = engine.journal.standardize(JOURNAL)
+    JOURNAL = engine.journal.standardize(JOURNAL)
     TAX_CODES = engine.tax_codes.standardize(TAX_CODES)
     REVALUATIONS = engine.revaluations.standardize(REVALUATIONS)
     PROFIT_CENTERS = engine.profit_centers.standardize(PROFIT_CENTERS)

--- a/pyledger/tests/base_test_accounts.py
+++ b/pyledger/tests/base_test_accounts.py
@@ -157,7 +157,7 @@ class BaseTestAccounts(BaseTest):
     def test_account_balance(self, restored_engine):
         restored_engine.restore(
             accounts=self.ACCOUNTS, configuration=self.CONFIGURATION, tax_codes=self.TAX_CODES,
-            journal=self.JOURNAL_ENTRIES, assets=self.ASSETS, price_history=self.PRICES,
+            journal=self.JOURNAL, assets=self.ASSETS, price_history=self.PRICES,
             revaluations=self.REVALUATIONS, profit_centers=self.PROFIT_CENTERS
         )
         # Test account balance with specified profit centers
@@ -175,8 +175,8 @@ class BaseTestAccounts(BaseTest):
             )
 
         # Test account balance without specified profit centers
-        JOURNAL_ENTRIES = self.JOURNAL_ENTRIES.copy().assign(profit_center=pd.NA)
-        restored_engine.restore(profit_centers=[], journal=JOURNAL_ENTRIES)
+        JOURNAL = self.JOURNAL.copy().assign(profit_center=pd.NA)
+        restored_engine.restore(profit_centers=[], journal=JOURNAL)
         EXPECTED_BALANCE_NO_PROFIT_CENTERS = self.EXPECTED_BALANCE.query("profit_center.isna()")
         for _, row in EXPECTED_BALANCE_NO_PROFIT_CENTERS.iterrows():
             date = datetime.datetime.strptime(row['date'], "%Y-%m-%d").date()

--- a/pyledger/tests/base_test_dump_restore_clear.py
+++ b/pyledger/tests/base_test_dump_restore_clear.py
@@ -18,7 +18,7 @@ class BaseTestDumpRestoreClear(BaseTest):
             configuration=self.CONFIGURATION,
             accounts=self.ACCOUNTS,
             tax_codes=self.TAX_CODES,
-            journal=self.JOURNAL_ENTRIES,
+            journal=self.JOURNAL,
             assets=self.ASSETS,
             price_history=self.PRICES,
             revaluations=self.REVALUATIONS,
@@ -41,7 +41,7 @@ class BaseTestDumpRestoreClear(BaseTest):
         )
         assert_frame_equal(self.ASSETS, engine.assets.list(), ignore_row_order=True)
         assert_frame_equal(self.PROFIT_CENTERS, engine.profit_centers.list(), ignore_row_order=True)
-        target = engine.txn_to_str(self.JOURNAL_ENTRIES).values()
+        target = engine.txn_to_str(self.JOURNAL).values()
         actual = engine.txn_to_str(engine.journal.list()).values()
         assert sorted(target) == sorted(actual), "Targeted and actual journal differ"
 
@@ -50,7 +50,7 @@ class BaseTestDumpRestoreClear(BaseTest):
         engine.reporting_currency = self.CONFIGURATION["REPORTING_CURRENCY"]
         engine.accounts.mirror(self.ACCOUNTS)
         engine.tax_codes.mirror(self.TAX_CODES)
-        engine.journal.mirror(self.JOURNAL_ENTRIES)
+        engine.journal.mirror(self.JOURNAL)
         engine.assets.mirror(self.ASSETS)
         engine.price_history.mirror(self.PRICES)
         engine.revaluations.mirror(self.REVALUATIONS)
@@ -99,7 +99,7 @@ class BaseTestDumpRestoreClear(BaseTest):
             configuration=self.CONFIGURATION,
             accounts=self.ACCOUNTS,
             tax_codes=self.TAX_CODES,
-            journal=self.JOURNAL_ENTRIES,
+            journal=self.JOURNAL,
             assets=self.ASSETS,
             price_history=self.PRICES,
             revaluations=self.REVALUATIONS,

--- a/pyledger/tests/test_serialized_ledger_cache.py
+++ b/pyledger/tests/test_serialized_ledger_cache.py
@@ -22,7 +22,7 @@ def engine():
         configuration=BaseTest.CONFIGURATION,
         tax_codes=BaseTest.TAX_CODES,
         accounts=BaseTest.ACCOUNTS,
-        journal=BaseTest.JOURNAL_ENTRIES,
+        journal=BaseTest.JOURNAL,
         price_history=BaseTest.PRICES,
         profit_centers=BaseTest.PROFIT_CENTERS
     )

--- a/pyledger/tests/test_text_ledger_journal.py
+++ b/pyledger/tests/test_text_ledger_journal.py
@@ -19,10 +19,10 @@ class TestLedger(BaseTestJournal):
 
     def test_write_journal_directory(self, engine):
         # Define journal entries with different nesting level
-        file_1 = self.JOURNAL_ENTRIES.copy()
+        file_1 = self.JOURNAL.copy()
         file_1["id"] = "level1/level2/file1.csv:" + file_1["id"]
         ids = [str(id) for id in range(11, 15)]
-        file_2 = self.JOURNAL_ENTRIES.query(f"id in {ids}")
+        file_2 = self.JOURNAL.query(f"id in {ids}")
         id = file_2["id"].astype(int)
         file_2["id"] = "file2.csv:" + (id - min(id) + 1).astype(str)
 
@@ -59,11 +59,11 @@ class TestLedger(BaseTestJournal):
 
     def test_extra_columns(self, engine):
         extra_cols = ["new_column", "second_new_column"]
-        entries = self.JOURNAL_ENTRIES.query("id in ['1', '2']").copy()
+        entries = self.JOURNAL.query("id in ['1', '2']").copy()
         ids = engine.journal.add(entries)  # noqa: F841
 
         # Add journal entries with a new column
-        expected = self.JOURNAL_ENTRIES.query("id in ['3', '4']").copy()
+        expected = self.JOURNAL.query("id in ['3', '4']").copy()
         expected[extra_cols[0]] = "test value"
         engine.journal.add(expected)
         current = engine.journal.list()

--- a/pyledger/tests/test_txn_to_str.py
+++ b/pyledger/tests/test_txn_to_str.py
@@ -41,25 +41,25 @@ EXPECTED = {
     )
 }
 
-JOURNAL_ENTRIES = pd.read_csv(StringIO(JOURNAL_CSV), skipinitialspace=True)
+JOURNAL = pd.read_csv(StringIO(JOURNAL_CSV), skipinitialspace=True)
 
 
 def test_txn_to_str():
     engine = MemoryLedger()
-    result = engine.txn_to_str(JOURNAL_ENTRIES)
+    result = engine.txn_to_str(JOURNAL)
     assert result == EXPECTED, "Transactions were not converted correctly."
 
 
 def test_txn_to_str_empty_df():
     engine = MemoryLedger()
-    df = pd.DataFrame(columns=JOURNAL_ENTRIES.columns)
+    df = pd.DataFrame(columns=JOURNAL.columns)
     result = engine.txn_to_str(df)
     assert result == {}, "Empty DataFrame did not return an empty dict."
 
 
 def test_txn_to_str_non_unique_dates():
     engine = MemoryLedger()
-    df = JOURNAL_ENTRIES[JOURNAL_ENTRIES["id"].isin(['1', '4'])]
+    df = JOURNAL[JOURNAL["id"].isin(['1', '4'])]
     df.loc[df["id"] == '4', "id"] = '1'
     with pytest.raises(ValueError):
         engine.txn_to_str(df)
@@ -67,7 +67,7 @@ def test_txn_to_str_non_unique_dates():
 
 def test_txn_to_str_variations_of_same_transactions():
     engine = MemoryLedger()
-    df1 = JOURNAL_ENTRIES[JOURNAL_ENTRIES["id"] == 2]
+    df1 = JOURNAL[JOURNAL["id"] == 2]
     # Reverse the column order
     df2 = df1[df1.columns[::-1]]
     # Shuffle rows


### PR DESCRIPTION
- rename `JOURNAL_ENTRIES` to `JOURNAL` (same meaning, but more concise)
- rename `ledger` in README example to `engine` (align with our current conventions)