### PR TITLE
Fix: Transactions missing in account history of contra account

### DIFF
--- a/pyledger/standalone_ledger.py
+++ b/pyledger/standalone_ledger.py
@@ -202,8 +202,10 @@ class StandaloneLedger(LedgerEngine):
         automated_entries = self.generate_automated_entries(
             df, target_balances=target_balances, revaluations=revaluations
         )
+        df = self.serialize_ledger(df)
+
         if not automated_entries.empty:
-            df = pd.concat([self.serialize_ledger(df), automated_entries], ignore_index=True)
+            df = pd.concat([df, automated_entries], ignore_index=True)
 
         return df
 


### PR DESCRIPTION
This PR fixes missing contra account entries in account history.

* **bca8741** – Add test exposing the issue (#193)
* **f237311** – Fix by always serializing both sides of the transaction

